### PR TITLE
Add theme meta data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "slevomat/coding-standard": "^8.15",
         "szepeviktor/phpstan-wordpress": "^1.3",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan-strict-rules": "^1.6"
+        "phpstan/phpstan-strict-rules": "^1.6",
+        "phpstan/phpstan": "^1.12"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89362dbed51c1d8e81f7fc9c2ec0c2e0",
+    "content-hash": "694b8542b5c0e6064d2a23ce13146f16",
     "packages": [],
     "packages-dev": [
         {
@@ -596,16 +596,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.8",
+            "version": "1.12.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec"
+                "reference": "84cbf8f018e01834b9b1ac3dacf3b9780e209e53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec",
-                "reference": "6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/84cbf8f018e01834b9b1ac3dacf3b9780e209e53",
+                "reference": "84cbf8f018e01834b9b1ac3dacf3b9780e209e53",
                 "shasum": ""
             },
             "require": {
@@ -650,7 +650,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-24T07:01:22+00:00"
+            "time": "2025-05-14T11:08:32+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
@@ -1054,10 +1054,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/class-performance-wizard-data-source-themes-and-plugins.php
+++ b/includes/class-performance-wizard-data-source-themes-and-plugins.php
@@ -24,7 +24,7 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 		Lighthouse provides a path to scripts that are causing performance issues and for assets enqueued by plugins, this will usually include the plugin slug as part of the path (typically /wp-content/plugins/{slug}/path...). Use this information to correlate plugins to the assets they enqueue.
 		The plugin meta data returned includes additional quality signals, such as an overall rating, counts of 1-5 star reviews, and fields for support_threads and support_threads_resolved which indicate support responsiveness. Use this information when comparing plugins or considering disabling a plugin.'
 		);
-		$this->set_data_shape( "The returned data for each plugin includes the name, slug, version, author, description, URI  and a field named 'plugin_api_data' which contains the metadata about the plugin from the wordpress.org plugin API. This metadata includes a rating field with an overall rating (0-100) of the plugin, as well as a ratings object with the number of 1 star (worst) thru 5 star (best) reviews, as well as fields for support_threads and support_threads_resolved ." );
+		$this->set_data_shape( "The returned data includes an 'active_theme' object and an 'active_plugins' array. The active_theme object contains name, slug, version, author, description, is_block_theme (boolean indicating Full Site Editing support), and a 'theme_api_data' field with metadata from the wordpress.org theme API. Each entry in active_plugins includes the name, slug, version, author, description, URI and a field named 'plugin_api_data' which contains the metadata about the plugin from the wordpress.org plugin API. This metadata includes a rating field with an overall rating (0-100) of the plugin, as well as a ratings object with the number of 1 star (worst) thru 5 star (best) reviews, as well as fields for support_threads and support_threads_resolved ." );
 	}
 
 	/**
@@ -40,6 +40,10 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 
 		// Check for errors.
 		if ( is_wp_error( $response ) ) {
+			return '';
+		}
+
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return '';
 		}
 
@@ -61,11 +65,18 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 		if ( is_wp_error( $response ) ) {
 			return '';
 		}
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return '';
+		}
 		return wp_remote_retrieve_body( $response );
 	}
 
 	/**
 	 * Get the active theme and plugins data and return in a structured data object.
+	 *
+	 * The returned JSON contains an 'active_theme' object (including wordpress.org
+	 * theme API metadata and a block theme indicator) and an 'active_plugins' array
+	 * with per-plugin metadata augmented by wordpress.org plugin API data.
 	 *
 	 * @return string JSON encoded string of the active theme and plugins data.
 	 */
@@ -107,11 +118,11 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 		}
 
 		// Theme slug is usually the stylesheet (directory) name.
-		$theme_slug = $active_theme->get_stylesheet();
+		$theme_slug     = $active_theme->get_stylesheet();
 		$theme_api_data = $this->get_theme_data_from_dotorg_api( $theme_slug );
 
 		// Detect if the theme is a block theme (WP 5.9+).
-		$is_block_theme = function_exists('wp_is_block_theme') ? wp_is_block_theme() : ( file_exists( get_theme_root() . '/' . $theme_slug . '/theme.json' ) );
+		$is_block_theme = function_exists( 'wp_is_block_theme' ) ? wp_is_block_theme() : ( file_exists( get_theme_root() . '/' . $theme_slug . '/theme.json' ) );
 
 		$theme_data = array(
 			'name'           => $active_theme->get( 'Name' ),
@@ -119,11 +130,11 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 			'author'         => $active_theme->get( 'Author' ),
 			'description'    => $active_theme->get( 'Description' ),
 			'slug'           => $theme_slug,
-			'is_block_theme' => (bool) $is_block_theme,
+			'is_block_theme' => $is_block_theme,
 			'theme_api_data' => $theme_api_data,
 		);
 
-		$to_return  = array(
+		$to_return = array(
 			'active_theme'   => $theme_data,
 			'active_plugins' => $plugins_data,
 		);


### PR DESCRIPTION
Fixes https://github.com/adamsilverstein/wp-performance-wizard/issues/16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Returns richer site inventory: a single payload with active theme details and an array of active plugins, including metadata fetched from WordPress.org.
  * Detects block-theme status to improve theme classification and guidance.

* **Chores**
  * Updated development tooling to enhance static analysis and code quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->