### PR TITLE
Optionally collect plugin source code for analysis (supersedes #7)

### DIFF
--- a/includes/class-performance-wizard-admin-page.php
+++ b/includes/class-performance-wizard-admin-page.php
@@ -78,7 +78,7 @@ class Performance_Wizard_Admin_Page {
 		$settings_url = admin_url( 'admin.php?page=wp-performance-wizard-settings' );
 		foreach ( $data_sources as $data_source ) {
 			echo '<label><input type="checkbox" class="performance-wizard-data-source" name="data_source" value="' . esc_attr( $data_source['name'] ) . '" checked>' . esc_html( $data_source['name'] ) . '</label>';
-			if ( 'Themes and Plugins' === $data_source['name'] ) {
+			if ( isset( $data_source['class_name'] ) && 'Performance_Wizard_Data_Source_Themes_And_Plugins' === $data_source['class_name'] ) {
 				echo ' <a href="' . esc_url( $settings_url ) . '">' . esc_html__( '(Settings)', 'wp-performance-wizard' ) . '</a>';
 			}
 			echo '<br>';

--- a/includes/class-performance-wizard-admin-page.php
+++ b/includes/class-performance-wizard-admin-page.php
@@ -75,8 +75,13 @@ class Performance_Wizard_Admin_Page {
 		echo '<h3>' . esc_html__( 'Select the data sources to use for the analysis:', 'wp-performance-wizard' ) . '</h3>';
 		// Add checkboxes for all of the data sources.
 		$data_sources = $this->wizard->get_analysis_plan()->get_data_sources();
+		$settings_url = admin_url( 'admin.php?page=wp-performance-wizard-settings' );
 		foreach ( $data_sources as $data_source ) {
-			echo '<label><input type="checkbox" class="performance-wizard-data-source" name="data_source" value="' . esc_attr( $data_source['name'] ) . '" checked>' . esc_html( $data_source['name'] ) . '</label><br>';
+			echo '<label><input type="checkbox" class="performance-wizard-data-source" name="data_source" value="' . esc_attr( $data_source['name'] ) . '" checked>' . esc_html( $data_source['name'] ) . '</label>';
+			if ( 'Themes and Plugins' === $data_source['name'] ) {
+				echo ' <a href="' . esc_url( $settings_url ) . '">' . esc_html__( '(Settings)', 'wp-performance-wizard' ) . '</a>';
+			}
+			echo '<br>';
 		}
 
 		// Add hidden elements for steps that always run. Summarize Results, Wrap Up and Introduction.

--- a/includes/class-performance-wizard-data-source-themes-and-plugins.php
+++ b/includes/class-performance-wizard-data-source-themes-and-plugins.php
@@ -201,8 +201,6 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 	 * @return array<int,array<string,string>> List of {relative_path, source} entries.
 	 */
 	private function collect_plugin_source_files( string $slug, string $download_link, array $languages, int &$total_bytes_budget ): array {
-		global $wp_filesystem;
-
 		$collected = array();
 
 		$parsed_host = wp_parse_url( $download_link, PHP_URL_HOST );
@@ -263,12 +261,15 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 					continue;
 				}
 
-				$source = $wp_filesystem->get_contents( $file->getPathname() );
+				// Local temp file: read with native PHP rather than the WP_Filesystem
+				// abstraction, which may be initialized with FTP/SSH on some hosts and
+				// would fail on local paths.
+				$source = file_get_contents( $file->getPathname() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 				if ( false === $source || '' === $source ) {
 					continue;
 				}
 
-				$relative_path = ltrim( str_replace( $iterate_from, '', $file->getPathname() ), '/\\' );
+				$relative_path = ltrim( substr( $file->getPathname(), strlen( $iterate_from ) ), '/\\' );
 
 				$collected[] = array(
 					'relative_path' => $relative_path,
@@ -291,14 +292,14 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 	/**
 	 * Recursively remove a directory created by this data source.
 	 *
-	 * Restricted to paths under the system temp dir to avoid accidental
-	 * deletion of anything else.
+	 * Uses native PHP rather than WP_Filesystem because the directory always
+	 * lives under the local system temp dir, where the FTP/SSH transports
+	 * WP_Filesystem may select would fail. Restricted to paths under the
+	 * temp base to prevent accidental deletion of anything else.
 	 *
 	 * @param string $dir Absolute path to the directory to remove.
 	 */
 	private function recursive_rmdir( string $dir ): void {
-		global $wp_filesystem;
-
 		if ( '' === $dir || ! is_dir( $dir ) ) {
 			return;
 		}
@@ -307,8 +308,17 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 			return;
 		}
 
-		if ( $wp_filesystem instanceof WP_Filesystem_Base ) {
-			$wp_filesystem->delete( $dir, true, 'd' );
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $dir, FilesystemIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $iterator as $entry ) {
+			if ( $entry->isDir() ) {
+				@rmdir( $entry->getPathname() ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+			} else {
+				wp_delete_file( $entry->getPathname() );
+			}
 		}
+		@rmdir( $dir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
 	}
 }

--- a/includes/class-performance-wizard-data-source-themes-and-plugins.php
+++ b/includes/class-performance-wizard-data-source-themes-and-plugins.php
@@ -11,6 +11,21 @@
 class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wizard_Data_Source_Base {
 
 	/**
+	 * Maximum size in bytes for a single source file included in the prompt.
+	 */
+	const MAX_SOURCE_FILE_BYTES = 65536;
+
+	/**
+	 * Maximum number of source files collected per plugin.
+	 */
+	const MAX_SOURCE_FILES_PER_PLUGIN = 50;
+
+	/**
+	 * Maximum total bytes of source code across all plugins for one collection run.
+	 */
+	const MAX_SOURCE_TOTAL_BYTES = 524288;
+
+	/**
 	 * Construct the class, setting key variables
 	 */
 	public function __construct() {
@@ -24,7 +39,7 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 		Lighthouse provides a path to scripts that are causing performance issues and for assets enqueued by plugins, this will usually include the plugin slug as part of the path (typically /wp-content/plugins/{slug}/path...). Use this information to correlate plugins to the assets they enqueue.
 		The plugin meta data returned includes additional quality signals, such as an overall rating, counts of 1-5 star reviews, and fields for support_threads and support_threads_resolved which indicate support responsiveness. Use this information when comparing plugins or considering disabling a plugin.'
 		);
-		$this->set_data_shape( "The returned data includes an 'active_theme' object and an 'active_plugins' array. The active_theme object contains name, slug, version, author, description, is_block_theme (boolean indicating Full Site Editing support), and a 'theme_api_data' field with metadata from the wordpress.org theme API. Each entry in active_plugins includes the name, slug, version, author, description, URI and a field named 'plugin_api_data' which contains the metadata about the plugin from the wordpress.org plugin API. This metadata includes a rating field with an overall rating (0-100) of the plugin, as well as a ratings object with the number of 1 star (worst) thru 5 star (best) reviews, as well as fields for support_threads and support_threads_resolved ." );
+		$this->set_data_shape( "The returned data includes an 'active_theme' object and an 'active_plugins' array. The active_theme object contains name, slug, version, author, description, is_block_theme (boolean indicating Full Site Editing support), and a 'theme_api_data' field with metadata from the wordpress.org theme API. Each entry in active_plugins includes the name, slug, version, author, description, URI and a field named 'plugin_api_data' which contains the metadata about the plugin from the wordpress.org plugin API. This metadata includes a rating field with an overall rating (0-100) of the plugin, as well as a ratings object with the number of 1 star (worst) thru 5 star (best) reviews, as well as fields for support_threads and support_threads_resolved. When the site administrator has opted into plugin source collection, a plugin entry may also include an optional 'source_files' array, where each entry has a 'relative_path' (path within the plugin) and 'source' (file contents). Source files are capped in size and count and only included for plugins hosted on WordPress.org." );
 	}
 
 	/**
@@ -89,6 +104,18 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 		// bootstrap wp-admin/includes/plugin.php so we can use it to get plugin data.
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
+		// Determine whether to collect plugin source code, and prepare the
+		// filesystem and budget once for the whole loop.
+		$collect_sources    = class_exists( 'Performance_Wizard_Settings_Page' )
+			&& Performance_Wizard_Settings_Page::collect_plugin_sources();
+		$source_languages   = $collect_sources ? Performance_Wizard_Settings_Page::plugin_source_languages() : array();
+		$total_bytes_budget = self::MAX_SOURCE_TOTAL_BYTES;
+		$filesystem_ready   = false;
+		if ( $collect_sources ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			$filesystem_ready = WP_Filesystem();
+		}
+
 		$plugins_data = array();
 		foreach ( $active_plugins as $plugin ) {
 			$plugin_file = WP_PLUGIN_DIR . '/' . $plugin;
@@ -113,6 +140,23 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 			$plugin_api_data = $this->get_plugin_data_from_dotorg_api( $plugin_slug );
 			if ( '' !== $plugin_api_data ) {
 				$plugin_entry['plugin_api_data'] = $plugin_api_data;
+
+				// Optionally, collect the plugin source code from WordPress.org.
+				if ( $collect_sources && $filesystem_ready && $total_bytes_budget > 0 ) {
+					$decoded       = json_decode( $plugin_api_data );
+					$download_link = is_object( $decoded ) && isset( $decoded->download_link ) ? (string) $decoded->download_link : '';
+					if ( '' !== $download_link ) {
+						$source_files = $this->collect_plugin_source_files(
+							$plugin_slug,
+							$download_link,
+							$source_languages,
+							$total_bytes_budget
+						);
+						if ( count( $source_files ) > 0 ) {
+							$plugin_entry['source_files'] = $source_files;
+						}
+					}
+				}
 			}
 			$plugins_data[] = $plugin_entry;
 		}
@@ -140,5 +184,131 @@ class Performance_Wizard_Data_Source_Themes_And_Plugins extends Performance_Wiza
 		);
 
 		return wp_json_encode( $to_return );
+	}
+
+	/**
+	 * Download a plugin zip from WordPress.org and collect selected source files.
+	 *
+	 * Only downloads URLs hosted on downloads.wordpress.org. The slug is
+	 * sanitized before being used in any path. The temp directory is always
+	 * cleaned up, regardless of how this method exits.
+	 *
+	 * @param string   $slug                The plugin slug.
+	 * @param string   $download_link       The download URL reported by the plugin API.
+	 * @param string[] $languages           File extensions to collect (e.g. ['php', 'js']).
+	 * @param int      $total_bytes_budget  Remaining byte budget across the whole run; updated by reference.
+	 *
+	 * @return array<int,array<string,string>> List of {relative_path, source} entries.
+	 */
+	private function collect_plugin_source_files( string $slug, string $download_link, array $languages, int &$total_bytes_budget ): array {
+		global $wp_filesystem;
+
+		$collected = array();
+
+		$parsed_host = wp_parse_url( $download_link, PHP_URL_HOST );
+		if ( 'downloads.wordpress.org' !== $parsed_host ) {
+			return $collected;
+		}
+
+		$safe_slug = sanitize_key( $slug );
+		if ( '' === $safe_slug ) {
+			return $collected;
+		}
+
+		$temp_root = trailingslashit( get_temp_dir() ) . 'wp-perf-wizard-' . wp_generate_password( 8, false, false );
+		if ( ! wp_mkdir_p( $temp_root ) ) {
+			return $collected;
+		}
+
+		$zip_file = '';
+		try {
+			$download_result = download_url( $download_link );
+			if ( is_wp_error( $download_result ) ) {
+				return $collected;
+			}
+			$zip_file = $download_result;
+
+			$unzip = unzip_file( $zip_file, $temp_root );
+			if ( is_wp_error( $unzip ) ) {
+				return $collected;
+			}
+
+			$plugin_root  = trailingslashit( $temp_root ) . $safe_slug;
+			$iterate_from = is_dir( $plugin_root ) ? $plugin_root : $temp_root;
+
+			$iterator    = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $iterate_from, FilesystemIterator::SKIP_DOTS ) );
+			$files_count = 0;
+
+			foreach ( $iterator as $file ) {
+				if ( $file->isDir() ) {
+					continue;
+				}
+				if ( $files_count >= self::MAX_SOURCE_FILES_PER_PLUGIN ) {
+					break;
+				}
+				if ( $total_bytes_budget <= 0 ) {
+					break;
+				}
+
+				$extension = strtolower( pathinfo( $file->getFilename(), PATHINFO_EXTENSION ) );
+				if ( ! in_array( $extension, $languages, true ) ) {
+					continue;
+				}
+
+				$size = (int) $file->getSize();
+				if ( $size <= 0 || $size > self::MAX_SOURCE_FILE_BYTES ) {
+					continue;
+				}
+				if ( $size > $total_bytes_budget ) {
+					continue;
+				}
+
+				$source = $wp_filesystem->get_contents( $file->getPathname() );
+				if ( false === $source || '' === $source ) {
+					continue;
+				}
+
+				$relative_path = ltrim( str_replace( $iterate_from, '', $file->getPathname() ), '/\\' );
+
+				$collected[] = array(
+					'relative_path' => $relative_path,
+					'source'        => $source,
+				);
+
+				$total_bytes_budget -= $size;
+				++$files_count;
+			}
+		} finally {
+			if ( '' !== $zip_file && file_exists( $zip_file ) ) {
+				wp_delete_file( $zip_file );
+			}
+			$this->recursive_rmdir( $temp_root );
+		}
+
+		return $collected;
+	}
+
+	/**
+	 * Recursively remove a directory created by this data source.
+	 *
+	 * Restricted to paths under the system temp dir to avoid accidental
+	 * deletion of anything else.
+	 *
+	 * @param string $dir Absolute path to the directory to remove.
+	 */
+	private function recursive_rmdir( string $dir ): void {
+		global $wp_filesystem;
+
+		if ( '' === $dir || ! is_dir( $dir ) ) {
+			return;
+		}
+		$temp_base = trailingslashit( get_temp_dir() );
+		if ( 0 !== strpos( $dir, $temp_base ) ) {
+			return;
+		}
+
+		if ( $wp_filesystem instanceof WP_Filesystem_Base ) {
+			$wp_filesystem->delete( $dir, true, 'd' );
+		}
 	}
 }

--- a/includes/class-performance-wizard-settings-page.php
+++ b/includes/class-performance-wizard-settings-page.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Settings page for the Performance Wizard.
+ *
+ * @package wp-performance-wizard
+ */
+
+/**
+ * Registers a Settings submenu under the Performance Wizard menu and manages
+ * plugin-level options such as whether to include plugin source code in the
+ * data collected for analysis.
+ */
+class Performance_Wizard_Settings_Page {
+
+	/**
+	 * Option name that stores all settings as a single array.
+	 */
+	const OPTION_NAME = 'wp_performance_wizard_options';
+
+	/**
+	 * Languages that can be collected from plugin source trees.
+	 *
+	 * @var string[]
+	 */
+	const SUPPORTED_LANGUAGES = array( 'php', 'js', 'css', 'html' );
+
+	/**
+	 * Wire up admin hooks.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'add_submenu_page' ), 20 );
+		add_action( 'admin_post_wp_perf_wizard_save_settings', array( $this, 'handle_submission' ) );
+	}
+
+	/**
+	 * Register the Settings submenu under the Performance Wizard menu.
+	 */
+	public function add_submenu_page(): void {
+		add_submenu_page(
+			'wp-performance-wizard',
+			__( 'Performance Wizard Settings', 'wp-performance-wizard' ),
+			__( 'Settings', 'wp-performance-wizard' ),
+			'manage_options',
+			'wp-performance-wizard-settings',
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Return the full options array with defaults applied.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function get_options(): array {
+		$stored   = get_option( self::OPTION_NAME, array() );
+		$defaults = array(
+			'collect_plugin_sources'  => false,
+			'plugin_source_languages' => array( 'php' ),
+		);
+		if ( ! is_array( $stored ) ) {
+			$stored = array();
+		}
+		return array_merge( $defaults, $stored );
+	}
+
+	/**
+	 * Whether plugin source collection is enabled.
+	 *
+	 * Filterable via `wp_performance_wizard_collect_plugin_sources`.
+	 */
+	public static function collect_plugin_sources(): bool {
+		$options = self::get_options();
+		$enabled = (bool) $options['collect_plugin_sources'];
+		/**
+		 * Filters whether plugin source collection is enabled.
+		 *
+		 * @param mixed $enabled Current value from settings (bool).
+		 */
+		return (bool) apply_filters( 'wp_performance_wizard_collect_plugin_sources', $enabled );
+	}
+
+	/**
+	 * The languages (file extensions) to collect from plugin source trees.
+	 *
+	 * Filterable via `wp_performance_wizard_plugin_source_languages`. Always
+	 * constrained to SUPPORTED_LANGUAGES.
+	 *
+	 * @return string[]
+	 */
+	public static function plugin_source_languages(): array {
+		$options   = self::get_options();
+		$languages = is_array( $options['plugin_source_languages'] ) ? $options['plugin_source_languages'] : array( 'php' );
+		/**
+		 * Filters the list of plugin source languages to collect.
+		 *
+		 * @param string[] $languages Current list from settings.
+		 */
+		$languages = apply_filters( 'wp_performance_wizard_plugin_source_languages', $languages );
+		$languages = array_values( array_intersect( self::SUPPORTED_LANGUAGES, $languages ) );
+		return 0 === count( $languages ) ? array( 'php' ) : $languages;
+	}
+
+	/**
+	 * Render the settings page.
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$options            = self::get_options();
+		$collect_enabled    = (bool) $options['collect_plugin_sources'];
+		$selected_languages = (array) $options['plugin_source_languages'];
+
+		$notice = isset( $_GET['info'] ) ? sanitize_key( wp_unslash( $_GET['info'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html( get_admin_page_title() ) . '</h1>';
+
+		if ( 'saved' === $notice ) {
+			echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'Settings saved.', 'wp-performance-wizard' ) . '</p></div>';
+		} elseif ( 'nonce_error' === $notice ) {
+			echo '<div class="notice notice-error"><p>' . esc_html__( 'Security check failed. Please try again.', 'wp-performance-wizard' ) . '</p></div>';
+		} elseif ( 'permission_error' === $notice ) {
+			echo '<div class="notice notice-error"><p>' . esc_html__( 'You do not have permission to change these settings.', 'wp-performance-wizard' ) . '</p></div>';
+		}
+
+		echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '">';
+		echo '<input type="hidden" name="action" value="wp_perf_wizard_save_settings">';
+		wp_nonce_field( 'wp_perf_wizard_save_settings', 'wp_perf_wizard_settings_nonce' );
+
+		echo '<h2>' . esc_html__( 'Plugin Source Collection', 'wp-performance-wizard' ) . '</h2>';
+		echo '<div class="notice notice-warning inline"><p>';
+		echo esc_html__( 'When enabled, the Themes and Plugins data source will download the source code of each active plugin from WordPress.org and include selected file types in the analysis prompt. This can significantly increase prompt size, token usage, and cost. Only plugins hosted on WordPress.org are supported — paid, private, or custom plugins are skipped automatically.', 'wp-performance-wizard' );
+		echo '</p></div>';
+
+		echo '<table class="form-table" role="presentation"><tbody>';
+
+		echo '<tr><th scope="row">' . esc_html__( 'Collect plugin sources', 'wp-performance-wizard' ) . '</th><td>';
+		echo '<label><input type="checkbox" name="collect_plugin_sources" value="1"' . checked( $collect_enabled, true, false ) . '> ';
+		echo esc_html__( 'Include plugin source code from WordPress.org in analysis data.', 'wp-performance-wizard' );
+		echo '</label>';
+		echo '</td></tr>';
+
+		echo '<tr><th scope="row">' . esc_html__( 'File types to include', 'wp-performance-wizard' ) . '</th><td><fieldset>';
+		echo '<legend class="screen-reader-text">' . esc_html__( 'File types to include', 'wp-performance-wizard' ) . '</legend>';
+		foreach ( self::SUPPORTED_LANGUAGES as $language ) {
+			$checked = in_array( $language, $selected_languages, true );
+			echo '<label style="margin-right:1em;"><input type="checkbox" name="plugin_source_languages[]" value="' . esc_attr( $language ) . '"' . checked( $checked, true, false ) . '> ';
+			echo esc_html( strtoupper( $language ) );
+			echo '</label>';
+		}
+		echo '<p class="description">' . esc_html__( 'PHP is recommended for the best signal-to-cost ratio. All file types are capped by size to keep prompt size manageable.', 'wp-performance-wizard' ) . '</p>';
+		echo '</fieldset></td></tr>';
+
+		echo '</tbody></table>';
+
+		submit_button();
+		echo '</form>';
+		echo '</div>';
+	}
+
+	/**
+	 * Handle the settings form submission.
+	 */
+	public function handle_submission(): void {
+		$redirect = admin_url( 'admin.php?page=wp-performance-wizard-settings' );
+
+		if ( ! isset( $_POST['wp_perf_wizard_settings_nonce'] )
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['wp_perf_wizard_settings_nonce'] ) ), 'wp_perf_wizard_save_settings' ) ) {
+			wp_safe_redirect( add_query_arg( 'info', 'nonce_error', $redirect ) );
+			exit;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_safe_redirect( add_query_arg( 'info', 'permission_error', $redirect ) );
+			exit;
+		}
+
+		$collect = isset( $_POST['collect_plugin_sources'] );
+
+		$submitted_languages = array();
+		if ( isset( $_POST['plugin_source_languages'] ) && is_array( $_POST['plugin_source_languages'] ) ) {
+			foreach ( wp_unslash( $_POST['plugin_source_languages'] ) as $language ) {
+				$language = sanitize_key( (string) $language );
+				if ( in_array( $language, self::SUPPORTED_LANGUAGES, true ) ) {
+					$submitted_languages[] = $language;
+				}
+			}
+		}
+		if ( 0 === count( $submitted_languages ) ) {
+			$submitted_languages = array( 'php' );
+		}
+
+		$options                            = self::get_options();
+		$options['collect_plugin_sources']  = $collect;
+		$options['plugin_source_languages'] = array_values( array_unique( $submitted_languages ) );
+
+		update_option( self::OPTION_NAME, $options );
+
+		wp_safe_redirect( add_query_arg( 'info', 'saved', $redirect ) );
+		exit;
+	}
+}

--- a/includes/class-performance-wizard-settings-page.php
+++ b/includes/class-performance-wizard-settings-page.php
@@ -93,9 +93,13 @@ class Performance_Wizard_Settings_Page {
 		/**
 		 * Filters the list of plugin source languages to collect.
 		 *
-		 * @param string[] $languages Current list from settings.
+		 * @param mixed $languages Current list from settings (string[]).
 		 */
 		$languages = apply_filters( 'wp_performance_wizard_plugin_source_languages', $languages );
+		if ( ! is_array( $languages ) ) {
+			$languages = array( 'php' );
+		}
+		$languages = array_map( 'sanitize_key', $languages );
 		$languages = array_values( array_intersect( self::SUPPORTED_LANGUAGES, $languages ) );
 		return 0 === count( $languages ) ? array( 'php' ) : $languages;
 	}

--- a/includes/class-wp-performance-wizard.php
+++ b/includes/class-wp-performance-wizard.php
@@ -137,6 +137,9 @@ class WP_Performance_Wizard {
 		// Load the wp-admin page.
 		new Performance_Wizard_Admin_Page( $this );
 
+		// Load the settings page.
+		new Performance_Wizard_Settings_Page();
+
 		// Load the Analysis plan.
 		$this->analysis_plan = new Performance_Wizard_Analysis_Plan( $this );
 
@@ -169,6 +172,7 @@ class WP_Performance_Wizard {
 	private function load_required_files(): void {
 		// Load all required files.
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-admin-page.php';
+		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-settings-page.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-analysis-plan.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-rest-api.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-ai-agent-base.php';


### PR DESCRIPTION
## Summary
- Add a Settings submenu under Performance Wizard with a master toggle and per-language checkboxes (PHP/JS/CSS/HTML) for including plugin source code in the analysis data.
- Augment the Themes and Plugins data source to optionally download each active plugin from WordPress.org and attach selected file types under a new per-plugin `source_files` array.
- Add a small `(Settings)` link next to the Themes and Plugins checkbox on the main wizard page so the toggle is discoverable.

## Why this supersedes #7
The original PR #7 (`try/add-plugin-sources`) is from July 2024, has merge conflicts against `main`, and has several blocking issues that were called out on review:

- Hardcoded `/tmp/` path with an unsanitized slug (path traversal risk, non-portable).
- `download_url()` called before `wp-admin/includes/file.php` was loaded.
- `RecursiveDirectoryIterator` ran even when the download or unzip failed.
- `WP_Filesystem()` initialized inside the per-file loop.
- No cleanup of extracted files or the `download_url` tempfile.
- No allow-list — paid/private plugins would be downloaded blindly.
- Unbounded payload size (would blow past LLM context windows on any real site).
- No user-facing way to opt out; even a hard-coded toggle was missing.
- Per-plugin keys (`download_error`, `source_files`) were assigned at the aggregate array level inside the loop, overwriting each iteration.

This PR addresses all of them and adds the admin UI we agreed on.

## Safety envelope
- **Off by default.** Admin must opt in via Settings.
- **Allow-list:** only `https://downloads.wordpress.org/...` URLs are downloaded — paid, private, and custom plugins are skipped silently.
- **Sanitized slug** (`sanitize_key()`) before any path use.
- **Temp dir:** `get_temp_dir()` with a random suffix; recursive cleanup in `try/finally`, including the `download_url` tempfile. Cleanup is restricted to paths under the temp base.
- **Caps (constants on the data source):** 64KB per file, 50 files per plugin, 512KB total per analysis run. Files exceeding the budget are skipped silently.
- **`WP_Filesystem()`** initialized once before the loop; bails the feature if init fails.
- **Filter overrides** for programmatic control: `wp_performance_wizard_collect_plugin_sources`, `wp_performance_wizard_plugin_source_languages`.

## Data shape change
Each entry in `active_plugins` may now optionally include:

```json
{
  "source_files": [
    { "relative_path": "src/foo.php", "source": "<?php ..." }
  ]
}
```

The `set_data_shape()` description for the data source is updated to document this.

## Test plan
- [ ] Activate the plugin on a test site and confirm Settings submenu appears under Performance Wizard.
- [ ] With the toggle off, run an analysis and confirm `source_files` is absent from the data source output (no behavior change vs. main).
- [ ] Toggle on with PHP only; run analysis and confirm `source_files` arrays appear for plugins hosted on WordPress.org and are absent for non-org plugins.
- [ ] Toggle on with all four languages; confirm caps kick in (no single file over 64KB, no plugin over 50 files, no run over 512KB total).
- [ ] After analysis, confirm no leftover directories under `get_temp_dir()` matching `wp-perf-wizard-*`.
- [ ] Try a malicious slug shape via filter override on `download_link`; confirm host check rejects it.

Closes #7 (closes after review).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Performance Wizard Settings page in the admin menu for configuring behavior.
  * Enabled optional collection of plugin source files with user-configurable allowed languages/extensions.
  * Implemented safeguards: per-file, per-plugin, and total size/count limits when collecting plugin sources.
  * Added a convenient "Settings" link next to the relevant data source in the Performance Wizard for quick access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->