### PR TITLE
Migrate to WordPress 7.0 Connectors API for AI credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 ## About
 Performance Wizard employs an AI agent to analyze your site performance and offer recommendations.
 
+## Requirements
+
+* WordPress 7.0 or later (required for the core Connectors API).
+* PHP 7.4 or later.
+
 ## Installation
 
 This plugin can be installed like any other WordPress plugin.
@@ -8,19 +13,19 @@ This plugin can be installed like any other WordPress plugin.
 1. Upload the `wp-performance-wizard` directory to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.
 
-## API Key
-To use the Gemini agent currently included in the project, you need to obtain an API key by visiting https://aistudio.google.com/app/apikey.
+## Connecting an AI provider
 
-Visit Performance Wizard -> Gemini to enter your API key, or manually create a file in the `.keys` directory dnamed `.keys/gemini-key.json` with this content:
+Performance Wizard uses WordPress 7.0's Connectors API for all provider credentials. It no longer stores API keys itself.
 
-```
-{
-	"apikey": "[YOUR_API_KEY]"
-}
-```
+1. In wp-admin, open the core **Connectors** screen.
+2. Find the connector that matches the AI provider you want to use (Google Gemini, OpenAI, or Anthropic) and add your API key.
+3. Return to **Performance Wizard** — any connector with a configured key is automatically offered as an analysis model.
+
+Credentials can also be supplied via environment variable or PHP constant using the Connectors API convention, e.g. `GEMINI_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY`. Values defined this way take precedence over database-stored keys.
+
 ## Usage
 
-After installing and activating the plugin, navigate to Performance Wizard -> Gemini in your WordPress admin dashboard.  Here, you can enter your API key for the Gemini agent.  You can then initiate a performance analysis of your site. The results and recommendations will be displayed on the same page.
+After installing and activating the plugin and connecting at least one AI provider, navigate to **Performance Wizard** in your WordPress admin dashboard. Choose the data sources to include, pick a configured AI model if more than one is available, and run the analysis. Results and recommendations are rendered inline.
 
 ## Development
 
@@ -49,6 +54,7 @@ composer run format
 See [docs/github-actions.md](docs/github-actions.md) for detailed information about the CI/CD setup.
 
 ## Versions
+* 2.0.0 - Require WordPress 7.0. Removed built-in API key UI; credentials are now supplied via the core Connectors API.
 * 1.3.1 - Added Gemini key entry in admin.
 * 1.3.0 - Added checkboxes to select which data sources to use.
 * 1.2.0 - Added the Script Attribution data source.

--- a/includes/class-performance-wizard-admin-page.php
+++ b/includes/class-performance-wizard-admin-page.php
@@ -42,14 +42,25 @@ class Performance_Wizard_Admin_Page {
 			'dashicons-performance',
 			90
 		);
-		// Add submenu pages for all supported agents that have them.
-		$supported_agents = $this->wizard->get_supported_agents();
-		foreach ( $supported_agents as $agent_name => $agent_class_name ) {
-			$agent_class = new $agent_class_name( $this->wizard );
-			if ( method_exists( $agent_class, 'add_submenu_page' ) ) {
-				$agent_class->add_submenu_page();
-			}
-		}
+	}
+
+	/**
+	 * Return a URL to the core Connectors admin screen.
+	 *
+	 * The precise slug is filterable so sites can point users at whatever
+	 * screen their WordPress install exposes the Connectors API on.
+	 *
+	 * @return string Admin URL to the Connectors screen.
+	 */
+	private function get_connectors_screen_url(): string {
+		$default = admin_url( 'admin.php?page=connectors' );
+		/**
+		 * Filters the URL of the core Connectors admin screen.
+		 *
+		 * @param mixed $url Default admin URL for the Connectors screen (string).
+		 */
+		$url = apply_filters( 'wp_performance_wizard_connectors_screen_url', $default );
+		return is_string( $url ) ? $url : $default;
 	}
 
 	/**
@@ -124,9 +135,8 @@ class Performance_Wizard_Admin_Page {
 
 		if ( 0 === $model_count ) {
 			echo '<div class="notice notice-warning"><p>';
-			echo esc_html__( 'No AI models are configured. Please configure at least one AI model to use the Performance Wizard.', 'wp-performance-wizard' );
-			echo ' <a href="' . esc_url( admin_url( 'admin.php?page=wp-performance-wizard-gemini' ) ) . '">' . esc_html__( 'Configure Gemini', 'wp-performance-wizard' ) . '</a>';
-			echo ' | <a href="' . esc_url( admin_url( 'admin.php?page=wp-performance-wizard-claude' ) ) . '">' . esc_html__( 'Configure Claude', 'wp-performance-wizard' ) . '</a>';
+			echo esc_html__( 'No AI models are configured. Connect an AI provider from the core Connectors screen to use the Performance Wizard.', 'wp-performance-wizard' );
+			echo ' <a href="' . esc_url( $this->get_connectors_screen_url() ) . '">' . esc_html__( 'Open Connectors', 'wp-performance-wizard' ) . '</a>';
 			echo '</p></div>';
 			return;
 		}

--- a/includes/class-performance-wizard-admin-page.php
+++ b/includes/class-performance-wizard-admin-page.php
@@ -53,14 +53,13 @@ class Performance_Wizard_Admin_Page {
 	 * @return string Admin URL to the Connectors screen.
 	 */
 	private function get_connectors_screen_url(): string {
-		$default = admin_url( 'admin.php?page=connectors' );
+		$default = admin_url( 'admin.php?page=options-connectors' );
 		/**
 		 * Filters the URL of the core Connectors admin screen.
 		 *
-		 * @param mixed $url Default admin URL for the Connectors screen (string).
+		 * @param string $url Default admin URL for the Connectors screen.
 		 */
-		$url = apply_filters( 'wp_performance_wizard_connectors_screen_url', $default );
-		return is_string( $url ) ? $url : $default;
+		return apply_filters( 'wp_performance_wizard_connectors_screen_url', $default );
 	}
 
 	/**

--- a/includes/class-performance-wizard-ai-agent-base.php
+++ b/includes/class-performance-wizard-ai-agent-base.php
@@ -168,10 +168,16 @@ class Performance_Wizard_AI_Agent_Base {
 	/**
 	 * Set the Connectors API connector ID this agent uses.
 	 *
+	 * Resets the cached key so the next get_api_key() call re-resolves against
+	 * the new connector's env var, constant, and option.
+	 *
 	 * @param string $connector_id The connector ID.
 	 */
 	public function set_connector_id( string $connector_id ): void {
-		$this->connector_id = $connector_id;
+		if ( $this->connector_id !== $connector_id ) {
+			$this->connector_id = $connector_id;
+			$this->api_key      = null;
+		}
 	}
 
 	/**

--- a/includes/class-performance-wizard-ai-agent-base.php
+++ b/includes/class-performance-wizard-ai-agent-base.php
@@ -2,7 +2,9 @@
 /**
  * A base class for AI agents, eg. Gemini, ChatGPT, etc.
  *
- * Includes the name of the agent, a way to store the API key and a method to invoke the API.
+ * Credentials are resolved through the WordPress 7.0 Connectors API. Agents
+ * declare a connector ID and the base class handles the env var / constant /
+ * option lookup order defined by that API.
  *
  * @package wp-performance-wizard
  */
@@ -11,25 +13,11 @@
  * The agent base class.
  */
 class Performance_Wizard_AI_Agent_Base {
-	/**
-	 * Encryption cipher method.
-	 */
-	protected const ENCRYPTION_CIPHER = 'aes-256-cbc';
 
 	/**
-	 * Number of iterations for key derivation.
-	 */
-	protected const PBKDF2_ITERATIONS = 10000;
-
-	/**
-	 * Length of derived key in bytes.
-	 */
-	protected const KEY_LENGTH = 32;
-
-	/**
-	 * The private API key.
+	 * Cached API key lookup result.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	private $api_key;
 
@@ -60,6 +48,13 @@ class Performance_Wizard_AI_Agent_Base {
 	 * @var string
 	 */
 	private $description;
+
+	/**
+	 * The Connectors API connector ID this agent reads credentials from.
+	 *
+	 * @var string
+	 */
+	private $connector_id = '';
 
 	/**
 	 * A method for calling the API of the AI agent.
@@ -162,179 +157,33 @@ class Performance_Wizard_AI_Agent_Base {
 	}
 
 	/**
-	 * Get the api key.
+	 * Get the Connectors API connector ID this agent uses.
 	 *
-	 * @return string The api key.
+	 * @return string The connector ID (e.g. 'anthropic', 'openai', 'gemini').
+	 */
+	public function get_connector_id(): string {
+		return $this->connector_id;
+	}
+
+	/**
+	 * Set the Connectors API connector ID this agent uses.
+	 *
+	 * @param string $connector_id The connector ID.
+	 */
+	public function set_connector_id( string $connector_id ): void {
+		$this->connector_id = $connector_id;
+	}
+
+	/**
+	 * Get the api key for this agent, resolved through the Connectors API.
+	 *
+	 * @return string The api key, or an empty string if not configured.
 	 */
 	public function get_api_key(): string {
 		if ( null === $this->api_key ) {
 			$this->api_key = $this->load_api_key();
 		}
 		return $this->api_key;
-	}
-
-	/**
-	 * Set the api key.
-	 *
-	 * @param string $api_key The api key.
-	 */
-	public function set_api_key( string $api_key ): void {
-		$this->api_key = $api_key;
-	}
-
-	/**
-	 * Encrypt and save the key.
-	 *
-	 * @param string $key The key to save.
-	 *
-	 * @return bool Whether the key was saved successfully.
-	 */
-	public function save_key( string $key ): bool {
-		$encrypted_key = $this->encrypt_key( $key );
-		$option_name   = $this->get_api_key_option_name();
-		return update_option( $option_name, $encrypted_key );
-	}
-
-	/**
-	 * Get the standardized option name for storing the API key.
-	 *
-	 * @return string The option name.
-	 */
-	protected function get_api_key_option_name(): string {
-		$agent_name = $this->get_name();
-		if ( '' === $agent_name ) {
-			return '';
-		}
-		$agent_slug = str_replace( ' ', '_', strtolower( $agent_name ) );
-		return 'wp_performance_wizard_' . $agent_slug . '_api_key';
-	}
-
-	/**
-	 * Encrypt the key.
-	 *
-	 * @param string $key The key to encrypt.
-	 *
-	 * @return string The encrypted key.
-	 */
-	public function encrypt_key( string $key ): string {
-		$cipher = self::ENCRYPTION_CIPHER;
-		$ivlen  = openssl_cipher_iv_length( $cipher );
-		$iv     = openssl_random_pseudo_bytes( $ivlen );
-		$salt   = openssl_random_pseudo_bytes( 32 );
-
-		if ( ! defined( 'SECURE_AUTH_KEY' ) || ! defined( 'SECURE_AUTH_SALT' ) ) {
-			return '';
-		}
-
-		$encryption_key = hash_pbkdf2(
-			'sha256',
-			SECURE_AUTH_KEY . SECURE_AUTH_SALT,
-			$salt,
-			self::PBKDF2_ITERATIONS,
-			self::KEY_LENGTH,
-			true
-		);
-
-		$encrypted = openssl_encrypt(
-			$key,
-			$cipher,
-			$encryption_key,
-			OPENSSL_RAW_DATA,
-			$iv
-		);
-
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		return base64_encode( $iv . $salt . $encrypted );
-	}
-
-	/**
-	 * Decrypt the key.
-	 *
-	 * @param string $encrypted_key The encrypted key to decrypt.
-	 *
-	 * @return string The decrypted key.
-	 */
-	public function decrypt_key( string $encrypted_key ): string {
-		if ( '' === $encrypted_key ) {
-			return '';
-		}
-
-		$cipher = self::ENCRYPTION_CIPHER;
-		$ivlen  = openssl_cipher_iv_length( $cipher );
-
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-		$combined = base64_decode( $encrypted_key, true );
-		if ( false === $combined ) {
-			return '';
-		}
-
-		$iv        = substr( $combined, 0, $ivlen );
-		$salt      = substr( $combined, $ivlen, 32 );
-		$encrypted = substr( $combined, $ivlen + 32 );
-
-		if ( ! defined( 'SECURE_AUTH_KEY' ) || ! defined( 'SECURE_AUTH_SALT' ) ) {
-			return '';
-		}
-
-		$encryption_key = hash_pbkdf2(
-			'sha256',
-			SECURE_AUTH_KEY . SECURE_AUTH_SALT,
-			$salt,
-			self::PBKDF2_ITERATIONS,
-			self::KEY_LENGTH,
-			true
-		);
-
-		$decrypted = openssl_decrypt(
-			$encrypted,
-			$cipher,
-			$encryption_key,
-			OPENSSL_RAW_DATA,
-			$iv
-		);
-
-		return ( false === $decrypted ) ? '' : $decrypted;
-	}
-
-	/**
-	 * Render status messages based on the 'info' GET parameter.
-	 *
-	 * This method handles common status messages for API key operations
-	 * and can be called by child classes in their render_admin_page methods.
-	 */
-	protected function render_status_messages(): void {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Just reading status parameter for display.
-		if ( ! isset( $_GET['info'] ) ) {
-			return;
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Just reading status parameter for display.
-		$info       = sanitize_text_field( $_GET['info'] );
-		$agent_name = $this->get_name();
-
-		switch ( $info ) {
-			case 'saved':
-				echo '<div class="notice notice-success"><p>API key saved successfully!</p></div>';
-				break;
-			case 'nonce_error':
-				echo '<div class="notice notice-error"><p>Security check failed. Please try again.</p></div>';
-				break;
-			case 'permission_error':
-				echo '<div class="notice notice-error"><p>You do not have permission to perform this action.</p></div>';
-				break;
-			case 'no_change':
-				echo '<div class="notice notice-warning"><p>No changes were made to the API key.</p></div>';
-				break;
-			case 'invalid_key':
-				echo '<div class="notice notice-error"><p>Invalid API key format. Please enter a valid ' . esc_html( $agent_name ) . ' API key.</p></div>';
-				break;
-			case 'save_failed':
-				echo '<div class="notice notice-error"><p>Failed to save API key. Please try again.</p></div>';
-				break;
-			case 'exception':
-				echo '<div class="notice notice-error"><p>An error occurred while saving the API key. Please check the error logs.</p></div>';
-				break;
-		}
 	}
 
 	/**
@@ -347,59 +196,36 @@ class Performance_Wizard_AI_Agent_Base {
 	}
 
 	/**
-	 * Function to load the API key for an agent.
+	 * Load the API key for this agent from the Connectors API.
 	 *
-	 * First tries to load from the encrypted option, then falls back to
-	 * the legacy option or JSON file.
+	 * Resolution order matches the Connectors API contract:
+	 *   1. Environment variable `{CONNECTOR_ID}_API_KEY`.
+	 *   2. PHP constant `{CONNECTOR_ID}_API_KEY`.
+	 *   3. Database option `connectors_ai_{connector_id}_api_key`.
 	 *
-	 * @return string The API key.
+	 * @return string The API key, or an empty string if none is configured.
 	 */
 	public function load_api_key(): string {
-		// First try to get the encrypted key from options.
-		$option_name   = $this->get_api_key_option_name();
-		$encrypted_key = get_option( $option_name );
-		$decrypted_key = '';
-
-		if ( is_string( $encrypted_key ) ) {
-			$decrypted_key = $this->decrypt_key( $encrypted_key );
-		}
-
-		if ( '' !== $decrypted_key ) {
-			return $decrypted_key;
-		}
-
-		// Fall back to legacy methods.
-		global $wp_filesystem;
-
-		$agent_name = $this->get_name();
-
-		if ( '' === $agent_name ) {
+		$connector_id = $this->get_connector_id();
+		if ( '' === $connector_id ) {
 			return '';
 		}
 
-		// Construct the slug from the name.
-		$agent_slug = str_replace( ' ', '-', strtolower( $agent_name ) );
+		$env_name = strtoupper( $connector_id ) . '_API_KEY';
 
-		// First check the options table.
-		$api_key = get_option( 'performance-wizard-api-key-' . $agent_slug );
-		if ( is_string( $api_key ) && '' !== $api_key ) {
-			return $api_key;
+		$env_value = getenv( $env_name );
+		if ( is_string( $env_value ) && '' !== $env_value ) {
+			return $env_value;
 		}
 
-		if ( ! defined( 'ABSPATH' ) || ! function_exists( 'WP_Filesystem' ) ) {
-			return '';
+		if ( defined( $env_name ) ) {
+			$constant_value = constant( $env_name );
+			if ( is_string( $constant_value ) && '' !== $constant_value ) {
+				return $constant_value;
+			}
 		}
 
-		// Next check the key file.
-		$filename = plugin_dir_path( __FILE__ ) . '../.keys/' . $agent_slug . '-key.json';
-		$path     = ABSPATH . 'wp-admin/includes/file.php';
-		if ( ! file_exists( $filename ) || ! is_readable( $filename ) ) {
-			return '';
-		}
-
-		require_once $path;
-		WP_Filesystem();
-		$keydata = json_decode( $wp_filesystem->get_contents( $filename ) );
-		return isset( $keydata->apikey ) ? $keydata->apikey : '';
+		$option_value = get_option( 'connectors_ai_' . $connector_id . '_api_key', '' );
+		return is_string( $option_value ) ? $option_value : '';
 	}
 }

--- a/includes/class-performance-wizard-ai-agent-chatgpt.php
+++ b/includes/class-performance-wizard-ai-agent-chatgpt.php
@@ -5,21 +5,14 @@
  * This file contains the ChatGPT AI agent implementation for the WordPress Performance Wizard.
  * It handles API connections to OpenAI's ChatGPT/GPT service.
  *
- * You can get a key for OpenAI API by visiting https://platform.openai.com/api-keys
- *
- * Copy the key into a file named chatgpt-key.json and place it in the .keys folder in the plugin directory.
+ * Credentials are supplied through the WordPress 7.0 Connectors API. Users
+ * configure their key from the core Connectors admin screen.
  *
  * @package wp-performance-wizard
  */
 
 /**
  * A class that enables connections to OpenAI ChatGPT.
- *
- * You can get a key for OpenAI API by visiting https://platform.openai.com/api-keys
- *
- * Copy the key into a file named chatgpt-key.json and place it in the .keys folder in the plugin directory.
- *
- * @package wp-performance-wizard
  */
 class Performance_Wizard_AI_Agent_ChatGPT extends Performance_Wizard_AI_Agent_Base {
 
@@ -32,7 +25,7 @@ class Performance_Wizard_AI_Agent_ChatGPT extends Performance_Wizard_AI_Agent_Ba
 		$this->set_name( 'ChatGPT' );
 		$this->set_wizard( $wizard );
 		$this->set_description( 'ChatGPT is a generative AI chatbot developed by OpenAI.' );
-		add_action( 'admin_post_handle_chatgpt_api_key_submission', array( $this, 'handle_api_key_submission' ), 10, 0 );
+		$this->set_connector_id( 'openai' );
 	}
 
 	/**
@@ -142,106 +135,5 @@ class Performance_Wizard_AI_Agent_ChatGPT extends Performance_Wizard_AI_Agent_Ba
 		}
 
 		return 'No response from ChatGPT.';
-	}
-
-	/**
-	 * Add a submenu page for ChatGPT Admin, including a field to enter the API key.
-	 */
-	public function add_submenu_page(): void {
-		// Add a submenu page for ChatGPT Admin, including a field to enter the API key. Goes as a sub menu under 'Performance Wizard'.
-		add_submenu_page(
-			'wp-performance-wizard',
-			__( 'ChatGPT', 'wp-performance-wizard' ),
-			__( 'ChatGPT', 'wp-performance-wizard' ),
-			'manage_options',
-			'wp-performance-wizard-chatgpt',
-			array( $this, 'render_admin_page' ),
-			1
-		);
-	}
-
-	/**
-	 * Render the ChatGPT Admin page.
-	 */
-	public function render_admin_page(): void {
-		echo '<h2>' . esc_attr( $this->get_name() ) . ' Admin</h2>';
-
-		// Show status messages using base class helper.
-		$this->render_status_messages();
-
-		$default_api_key = '';
-		$api_key         = $this->get_api_key();
-		if ( '' !== $api_key ) {
-			$default_api_key = str_repeat( '*', strlen( $api_key ) );
-		}
-
-		// Explain the ChatGPT API and where to get an API key.
-		echo '<p>ChatGPT is a generative artificial intelligence tool developed by OpenAI. You can get an API key by visiting <a href="https://platform.openai.com/api-keys" target="_blank">https://platform.openai.com/api-keys</a>.</p>';
-
-		// Add a form element, with a nonce field for security. Add as a WordPress action.
-		echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '">';
-		wp_nonce_field( 'save_chatgpt_api_key', 'chatgpt_api_key_nonce' );
-
-		echo '<input type="hidden" name="action" value="handle_chatgpt_api_key_submission">';
-
-		// Add a field for the API key.
-		echo '<label for="chatgpt-api-key">API Key</label> ';
-		echo '<input type="password" id="chatgpt-api-key" name="chatgpt-api-key" value="' . esc_attr( $default_api_key ) . '">';
-
-		// Add a hidden field with the default so we can skip if password is unchanged.
-		echo '<input type="hidden" name="default-chatgpt-api-key" value="' . esc_attr( $default_api_key ) . '">';
-
-		// Add a submit button.
-		echo '<input type="submit" class="button button-primary" value="Save">';
-		echo '</form>';
-	}
-
-	/**
-	 * Handle the API key submission.
-	 */
-	public function handle_api_key_submission(): void {
-		// Validate nonce.
-		if ( ! isset( $_POST['chatgpt_api_key_nonce'] ) || ! wp_verify_nonce( $_POST['chatgpt_api_key_nonce'], 'save_chatgpt_api_key' ) ) {
-			$url = isset( $_POST['_wp_http_referer'] ) ? $_POST['_wp_http_referer'] : admin_url( 'admin.php?page=wp-performance-wizard-chatgpt' );
-			wp_safe_redirect( add_query_arg( array( 'info' => 'nonce_error' ), $url ) );
-			exit;
-		}
-
-		// Check user capabilities.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			$url = isset( $_POST['_wp_http_referer'] ) ? $_POST['_wp_http_referer'] : admin_url( 'admin.php?page=wp-performance-wizard-chatgpt' );
-			wp_safe_redirect( add_query_arg( array( 'info' => 'permission_error' ), $url ) );
-			exit;
-		}
-
-		// Get and validate form data.
-		$api_key         = isset( $_POST['chatgpt-api-key'] ) ? sanitize_text_field( $_POST['chatgpt-api-key'] ) : '';
-		$url             = isset( $_POST['_wp_http_referer'] ) ? esc_url_raw( $_POST['_wp_http_referer'] ) : admin_url( 'admin.php?page=wp-performance-wizard-chatgpt' );
-		$default_api_key = isset( $_POST['default-chatgpt-api-key'] ) ? sanitize_text_field( $_POST['default-chatgpt-api-key'] ) : '';
-
-		// Check if the key was actually changed.
-		if ( $default_api_key === $api_key ) {
-			wp_safe_redirect( add_query_arg( array( 'info' => 'no_change' ), $url ) );
-			exit;
-		}
-
-		// Validate API key format - OpenAI keys typically start with 'sk-'.
-		if ( '' === $api_key || strlen( $api_key ) < 10 ) {
-			wp_safe_redirect( add_query_arg( array( 'info' => 'invalid_key' ), $url ) );
-			exit;
-		}
-
-		// Try to save the key.
-		try {
-			$saved = $this->save_key( $api_key );
-			if ( $saved ) {
-				wp_safe_redirect( add_query_arg( array( 'info' => 'saved' ), $url ) );
-			} else {
-				wp_safe_redirect( add_query_arg( array( 'info' => 'save_failed' ), $url ) );
-			}
-		} catch ( Exception $e ) {
-			wp_safe_redirect( add_query_arg( array( 'info' => 'exception' ), $url ) );
-		}
-		exit;
 	}
 }

--- a/includes/class-performance-wizard-ai-agent-claude.php
+++ b/includes/class-performance-wizard-ai-agent-claude.php
@@ -5,21 +5,14 @@
  * This file contains the Claude AI agent implementation for the WordPress Performance Wizard.
  * It handles API connections to Anthropic's Claude AI service.
  *
- * You can get a key for Claude API by visiting https://console.anthropic.com/settings/keys
- *
- * Copy the key into a file named claude-key.json and place it in the .keys folder in the plugin directory.
+ * Credentials are supplied through the WordPress 7.0 Connectors API. Users
+ * configure their key from the core Connectors admin screen.
  *
  * @package wp-performance-wizard
  */
 
 /**
  * A class that enables connections to Anthropic Claude AI.
- *
- * You can get a key for Claude API by visiting https://console.anthropic.com/settings/keys
- *
- * Copy the key into a file named claude-key.json and place it in the .keys folder in the plugin directory.
- *
- * @package wp-performance-wizard
  */
 class Performance_Wizard_AI_Agent_Claude extends Performance_Wizard_AI_Agent_Base {
 
@@ -32,7 +25,7 @@ class Performance_Wizard_AI_Agent_Claude extends Performance_Wizard_AI_Agent_Bas
 		$this->set_name( 'Claude' );
 		$this->set_wizard( $wizard );
 		$this->set_description( 'Claude is a generative AI chatbot developed by Anthropic.' );
-		add_action( 'admin_post_handle_claude_api_key_submission', array( $this, 'handle_api_key_submission' ), 10, 0 );
+		$this->set_connector_id( 'anthropic' );
 	}
 
 	/**
@@ -122,94 +115,5 @@ class Performance_Wizard_AI_Agent_Claude extends Performance_Wizard_AI_Agent_Bas
 			return $data['content'][0]['text'];
 		}
 		return 'No response from Claude.';
-	}
-
-	/**
-	 * Add a submenu page for Claude Admin, including a field to enter the API key.
-	 */
-	public function add_submenu_page(): void {
-		add_submenu_page(
-			'wp-performance-wizard',
-			__( 'Claude', 'wp-performance-wizard' ),
-			__( 'Claude', 'wp-performance-wizard' ),
-			'manage_options',
-			'wp-performance-wizard-claude',
-			array( $this, 'render_admin_page' ),
-			2
-		);
-	}
-
-	/**
-	 * Render the Claude Admin page.
-	 */
-	public function render_admin_page(): void {
-		echo '<h2>' . esc_attr( $this->get_name() ) . ' Admin</h2>';
-
-		// Show status messages using base class helper.
-		$this->render_status_messages();
-
-		$default_api_key = '';
-		$api_key         = $this->get_api_key();
-		if ( '' !== $api_key ) {
-			$default_api_key = str_repeat( '*', strlen( $api_key ) );
-		}
-		echo '<p>Claude is a generative AI tool developed by Anthropic. You can get an API key by visiting <a href="https://console.anthropic.com/settings/keys" target="_blank">https://console.anthropic.com/settings/keys</a>.</p>';
-		echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '">';
-		wp_nonce_field( 'save_claude_api_key', 'claude_api_key_nonce' );
-		echo '<input type="hidden" name="action" value="handle_claude_api_key_submission">';
-		echo '<label for="claude-api-key">API Key</label> ';
-		echo '<input type="password" id="claude-api-key" name="claude-api-key" value="' . esc_attr( $default_api_key ) . '">';
-		echo '<input type="hidden" name="default-claude-api-key" value="' . esc_attr( $default_api_key ) . '">';
-		echo '<input type="submit" class="button button-primary" value="Save">';
-		echo '</form>';
-	}
-
-	/**
-	 * Handle the API key submission.
-	 */
-	public function handle_api_key_submission(): void {
-		// Validate nonce.
-		if ( ! isset( $_POST['claude_api_key_nonce'] ) || ! wp_verify_nonce( $_POST['claude_api_key_nonce'], 'save_claude_api_key' ) ) {
-			$url = isset( $_POST['_wp_http_referer'] ) ? $_POST['_wp_http_referer'] : admin_url( 'admin.php?page=wp-performance-wizard-claude' );
-			wp_safe_redirect( add_query_arg( array( 'info' => 'nonce_error' ), $url ) );
-			exit;
-		}
-
-		// Check user capabilities.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			$url = isset( $_POST['_wp_http_referer'] ) ? $_POST['_wp_http_referer'] : admin_url( 'admin.php?page=wp-performance-wizard-claude' );
-			wp_safe_redirect( add_query_arg( array( 'info' => 'permission_error' ), $url ) );
-			exit;
-		}
-
-		// Get and validate form data.
-		$api_key         = isset( $_POST['claude-api-key'] ) ? sanitize_text_field( $_POST['claude-api-key'] ) : '';
-		$url             = isset( $_POST['_wp_http_referer'] ) ? esc_url_raw( $_POST['_wp_http_referer'] ) : admin_url( 'admin.php?page=wp-performance-wizard-claude' );
-		$default_api_key = isset( $_POST['default-claude-api-key'] ) ? sanitize_text_field( $_POST['default-claude-api-key'] ) : '';
-
-		// Check if the key was actually changed.
-		if ( $default_api_key === $api_key ) {
-			wp_safe_redirect( add_query_arg( array( 'info' => 'no_change' ), $url ) );
-			exit;
-		}
-
-		// Validate API key format.
-		if ( '' === $api_key || strlen( $api_key ) < 10 ) {
-			wp_safe_redirect( add_query_arg( array( 'info' => 'invalid_key' ), $url ) );
-			exit;
-		}
-
-		// Try to save the key.
-		try {
-			$saved = $this->save_key( $api_key );
-			if ( $saved ) {
-				wp_safe_redirect( add_query_arg( array( 'info' => 'saved' ), $url ) );
-			} else {
-				wp_safe_redirect( add_query_arg( array( 'info' => 'save_failed' ), $url ) );
-			}
-		} catch ( Exception $e ) {
-			wp_safe_redirect( add_query_arg( array( 'info' => 'exception' ), $url ) );
-		}
-		exit;
 	}
 }

--- a/includes/class-performance-wizard-ai-agent-gemini.php
+++ b/includes/class-performance-wizard-ai-agent-gemini.php
@@ -2,9 +2,8 @@
 /**
  * A class that enables connections to Gemini AI.
  *
- * You can get a key for Gemini API by visiting https://aistudio.google.com/app/apikey
- *
- * Copy the key into a file named gemini-key.json and place it in the .keys folder in the plugin directory.
+ * Credentials are supplied through the WordPress 7.0 Connectors API.
+ * Users configure their key from the core Connectors admin screen.
  *
  * @package wp-performance-wizard
  */
@@ -139,136 +138,9 @@ class Performance_Wizard_AI_Agent_Gemini extends Performance_Wizard_AI_Agent_Bas
 	 * @param WP_Performance_Wizard $wizard The performance wizard.
 	 */
 	public function __construct( WP_Performance_Wizard $wizard ) {
-		// Set the name.
 		$this->set_name( 'Gemini' );
 		$this->set_wizard( $wizard );
 		$this->set_description( 'Gemini is a is a generative artificial intelligence chatbot developed by Google.' );
-
-		// Add the handle_api_key_submission callback to the admin_post action.
-		add_action( 'admin_post_handle_gemini_api_key_submission', array( $this, 'handle_api_key_submission' ), 10, 0 );
-	}
-
-	/**
-	 * Add a submenu page for Gemini Admin, including a field to enter the API key.
-	 */
-	public function add_submenu_page(): void {
-		// Add a submenu page for Gemini Admin, including a field to enter the API key. Goes as a sub menu under 'Performance Wizard'.
-		add_submenu_page(
-			'wp-performance-wizard',
-			__( 'Gemini', 'wp-performance-wizard' ),
-			__( 'Gemini', 'wp-performance-wizard' ),
-			'manage_options',
-			'wp-performance-wizard-gemini',
-			array( $this, 'render_admin_page' ),
-			1
-		);
-	}
-
-	/**
-	 * Render the Gemini Admin page.
-	 */
-	public function render_admin_page(): void {
-		echo '<h2>' . esc_attr( $this->get_name() ) . ' Admin</h2>';
-
-		// Show status messages using base class helper.
-		$this->render_status_messages();
-
-		$default_api_key = '';
-		$api_key         = $this->get_api_key();
-		if ( '' !== $api_key ) {
-			$default_api_key = str_repeat( '*', strlen( $api_key ) );
-		}
-
-		// Explain the Gemini API and where to get an API key.
-		echo '<p>Gemini is a generative artificial intelligence tool developed by Google. You can get an API key by visiting <a href="https://aistudio.google.com/app/apikey" target="_blank">https://aistudio.google.com/app/apikey</a>.</p>';
-
-		// Add a form element, with a nonce field for security. Add as a WordPress action.
-		echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '">';
-		wp_nonce_field( 'save_gemini_api_key', 'gemini_api_key_nonce' );
-
-		echo '<input type="hidden" name="action" value="handle_gemini_api_key_submission">';
-
-		// Add a field for the API key.
-		echo '<label for="gemini-api-key">API Key</label> ';
-		echo '<input type="password" id="gemini-api-key" name="gemini-api-key" value="' . esc_attr( $default_api_key ) . '">';
-
-		// Add a hidden field with the default so we can skip if password is unchanged.
-		echo '<input type="hidden" name="default-gemini-api-key" value="' . esc_attr( $default_api_key ) . '">';
-
-		// Add a submit button.
-		echo '<input type="submit" class="button button-primary" value="Save">';
-		echo '</form>';
-		if ( '' !== $api_key ) {
-			$default_api_key = str_repeat( '*', strlen( $api_key ) );
-		}
-	}
-
-	/**
-	 * Handle the API key submission.
-	 */
-	public function handle_api_key_submission(): void {
-
-		// Validate the nonce.
-		if ( ! wp_verify_nonce( $_POST['gemini_api_key_nonce'], 'save_gemini_api_key' ) ) {
-			$url = $_POST['_wp_http_referer'];
-			wp_safe_redirect(
-				add_query_arg(
-					array(
-						'info' => 'nonce_error',
-					),
-					$url
-				)
-			);
-			exit;
-		}
-
-		$api_key = sanitize_text_field( $_POST['gemini-api-key'] );
-		$url     = esc_url_raw( $_POST['_wp_http_referer'] );
-
-		// Double check the user capabilities.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_safe_redirect(
-				add_query_arg(
-					array(
-						'info' => 'permission_error',
-					),
-					$url
-				)
-			);
-			exit;
-		}
-
-		// Validate API key format.
-		if ( '' === $api_key || strlen( $api_key ) < 10 ) {
-			wp_safe_redirect( add_query_arg( array( 'info' => 'invalid_key' ), $url ) );
-			exit;
-		}
-
-		$default_api_key = sanitize_text_field( $_POST['default-gemini-api-key'] );
-		if ( $default_api_key === $api_key ) {
-			wp_safe_redirect(
-				add_query_arg(
-					array(
-						'info' => 'no_change',
-					),
-					$url
-				)
-			);
-			exit;
-		}
-
-		// Save the API key. Save in the options table and use if key file is not available.
-		// Try to save the key.
-		try {
-			$saved = $this->save_key( $api_key );
-			if ( $saved ) {
-				wp_safe_redirect( add_query_arg( array( 'info' => 'saved' ), $url ) );
-			} else {
-				wp_safe_redirect( add_query_arg( array( 'info' => 'save_failed' ), $url ) );
-			}
-		} catch ( Exception $e ) {
-			wp_safe_redirect( add_query_arg( array( 'info' => 'exception' ), $url ) );
-		}
-		exit;
+		$this->set_connector_id( 'gemini' );
 	}
 }

--- a/includes/class-performance-wizard-connectors.php
+++ b/includes/class-performance-wizard-connectors.php
@@ -64,13 +64,9 @@ class Performance_Wizard_Connectors {
 	/**
 	 * Register any AI connectors that are not already present in the registry.
 	 *
-	 * @param object $registry The WP_Connector_Registry passed by wp_connectors_init.
+	 * @param \WP_Connector_Registry $registry Registry passed by wp_connectors_init.
 	 */
-	public function register_connectors( object $registry ): void {
-		if ( ! method_exists( $registry, 'register' ) || ! method_exists( $registry, 'is_registered' ) ) {
-			return;
-		}
-
+	public function register_connectors( \WP_Connector_Registry $registry ): void {
 		foreach ( self::get_default_connectors() as $id => $args ) {
 			if ( $registry->is_registered( $id ) ) {
 				continue;

--- a/includes/class-performance-wizard-connectors.php
+++ b/includes/class-performance-wizard-connectors.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Connectors API bootstrap for the Performance Wizard.
+ *
+ * Registers the AI provider connectors the plugin relies on if they have not
+ * already been registered by core or another plugin. Users configure the
+ * resulting credentials via the core Connectors admin screen.
+ *
+ * @package wp-performance-wizard
+ */
+
+/**
+ * Registers AI connectors used by the Performance Wizard.
+ */
+class Performance_Wizard_Connectors {
+
+	/**
+	 * Wire up the connectors bootstrap.
+	 */
+	public function __construct() {
+		add_action( 'wp_connectors_init', array( $this, 'register_connectors' ) );
+	}
+
+	/**
+	 * Default connector definitions the plugin will register if missing.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function get_default_connectors(): array {
+		return array(
+			'anthropic' => array(
+				'name'           => __( 'Anthropic', 'wp-performance-wizard' ),
+				'description'    => __( 'Text generation with Claude.', 'wp-performance-wizard' ),
+				'type'           => 'ai_provider',
+				'authentication' => array(
+					'method'          => 'api_key',
+					'credentials_url' => 'https://console.anthropic.com/settings/keys',
+					'setting_name'    => 'connectors_ai_anthropic_api_key',
+				),
+			),
+			'openai'    => array(
+				'name'           => __( 'OpenAI', 'wp-performance-wizard' ),
+				'description'    => __( 'Text generation with ChatGPT models.', 'wp-performance-wizard' ),
+				'type'           => 'ai_provider',
+				'authentication' => array(
+					'method'          => 'api_key',
+					'credentials_url' => 'https://platform.openai.com/api-keys',
+					'setting_name'    => 'connectors_ai_openai_api_key',
+				),
+			),
+			'gemini'    => array(
+				'name'           => __( 'Google Gemini', 'wp-performance-wizard' ),
+				'description'    => __( 'Text generation with Gemini models.', 'wp-performance-wizard' ),
+				'type'           => 'ai_provider',
+				'authentication' => array(
+					'method'          => 'api_key',
+					'credentials_url' => 'https://aistudio.google.com/app/apikey',
+					'setting_name'    => 'connectors_ai_gemini_api_key',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Register any AI connectors that are not already present in the registry.
+	 *
+	 * @param object $registry The WP_Connector_Registry passed by wp_connectors_init.
+	 */
+	public function register_connectors( object $registry ): void {
+		if ( ! method_exists( $registry, 'register' ) || ! method_exists( $registry, 'is_registered' ) ) {
+			return;
+		}
+
+		foreach ( self::get_default_connectors() as $id => $args ) {
+			if ( $registry->is_registered( $id ) ) {
+				continue;
+			}
+			$registry->register( $id, $args );
+		}
+	}
+}

--- a/includes/class-wp-performance-wizard.php
+++ b/includes/class-wp-performance-wizard.php
@@ -134,6 +134,9 @@ class WP_Performance_Wizard {
 	public function __construct() {
 		$this->load_required_files();
 
+		// Register AI provider connectors with the core Connectors API.
+		new Performance_Wizard_Connectors();
+
 		// Load the wp-admin page.
 		new Performance_Wizard_Admin_Page( $this );
 
@@ -172,6 +175,7 @@ class WP_Performance_Wizard {
 	private function load_required_files(): void {
 		// Load all required files.
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-admin-page.php';
+		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-connectors.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-settings-page.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-analysis-plan.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-rest-api.php';
@@ -181,28 +185,6 @@ class WP_Performance_Wizard {
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-ai-agent-chatgpt.php';
 	}
 
-
-	/**
-	 * Function to get the api key for a specific AI agent.
-	 *
-	 * The key is stored in a JSON file with the key "apikey".
-	 *
-	 * @param string $agent_name The name of the agent to get the key for.
-	 *
-	 * @return string The API key.
-	 */
-	public function get_api_key( string $agent_name ): string {
-		global $wp_filesystem;
-
-		if ( '' === $agent_name ) {
-			return '';
-		}
-		$filename = plugin_dir_path( __FILE__ ) . '../.keys/' . strtolower( $agent_name ) . '-key.json';
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-		WP_Filesystem();
-		$keydata = json_decode( $wp_filesystem->get_contents( $filename ) );
-		return isset( $keydata->apikey ) ? $keydata->apikey : '';
-	}
 
 	/**
 	 * Get the analysis plan class.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,4 +7,7 @@
 
 	<file>.</file>
 
+	<!-- Stubs exist only for static analysis and are not shipped code. -->
+	<exclude-pattern>*/stubs/*</exclude-pattern>
+
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,9 +7,12 @@ parameters:
 	ignoreErrors:
 	bootstrapFiles:
 		- wp-performance-wizard.php
+	scanFiles:
+		- stubs/wp-connectors.php
 	excludePaths:
 		- includes/js/
 		- includes/css/
 		- vendor/
 		- releases/
 		- tools/
+		- stubs/

--- a/stubs/wp-connectors.php
+++ b/stubs/wp-connectors.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Minimal PHPStan stubs for the WordPress 7.0 Connectors API.
+ *
+ * Not loaded at runtime — this file exists only so static analysis can resolve
+ * the Connectors API symbols the plugin depends on. The real implementations
+ * ship with WordPress core.
+ *
+ * @package wp-performance-wizard
+ */
+
+/**
+ * Registry passed to wp_connectors_init callbacks.
+ */
+class WP_Connector_Registry {
+	/**
+	 * Register a connector.
+	 *
+	 * @param string              $id   Connector ID.
+	 * @param array<string,mixed> $args Connector metadata.
+	 * @return bool
+	 */
+	public function register( string $id, array $args ): bool {
+		return true;
+	}
+
+	/**
+	 * Unregister and return a connector's metadata.
+	 *
+	 * @param string $id Connector ID.
+	 * @return array<string,mixed>|null
+	 */
+	public function unregister( string $id ): ?array {
+		return null;
+	}
+
+	/**
+	 * Whether a connector is registered.
+	 *
+	 * @param string $id Connector ID.
+	 * @return bool
+	 */
+	public function is_registered( string $id ): bool {
+		return false;
+	}
+
+	/**
+	 * Retrieve a single connector's metadata.
+	 *
+	 * @param string $id Connector ID.
+	 * @return array<string,mixed>|null
+	 */
+	public function get_registered( string $id ): ?array {
+		return null;
+	}
+
+	/**
+	 * Retrieve all registered connectors.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public function get_all_registered(): array {
+		return array();
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Test bootstrap: defines just enough WordPress surface for the base agent
+ * class to load outside of a real WordPress environment.
+ *
+ * @package wp-performance-wizard
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', '/' );
+}
+
+if ( ! isset( $GLOBALS['wp_performance_wizard_test_options'] ) ) {
+	$GLOBALS['wp_performance_wizard_test_options'] = array();
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	/**
+	 * Minimal get_option() stub backed by $GLOBALS.
+	 *
+	 * @param string $name    Option name.
+	 * @param mixed  $default Default value when the option is missing.
+	 * @return mixed
+	 */
+	function get_option( string $name, $default = false ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound
+		if ( isset( $GLOBALS['wp_performance_wizard_test_options'][ $name ] ) ) {
+			return $GLOBALS['wp_performance_wizard_test_options'][ $name ];
+		}
+		return $default;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-performance-wizard-ai-agent-base.php';

--- a/tests/test-wp-performance-wizard.php
+++ b/tests/test-wp-performance-wizard.php
@@ -46,4 +46,18 @@ class WP_Performance_Wizard_Test extends TestCase {
 
 		$this->assertSame( 'env-key', $agent->load_api_key() );
 	}
+
+	public function testPhpConstantBeatsOption(): void {
+		// Use a dedicated connector id so the defined constant does not leak into other tests.
+		$GLOBALS['wp_performance_wizard_test_options']['connectors_ai_wpperfconsttest_api_key'] = 'option-key';
+
+		if ( ! defined( 'WPPERFCONSTTEST_API_KEY' ) ) {
+			define( 'WPPERFCONSTTEST_API_KEY', 'constant-key' );
+		}
+
+		$agent = new Performance_Wizard_AI_Agent_Base();
+		$agent->set_connector_id( 'wpperfconsttest' );
+
+		$this->assertSame( 'constant-key', $agent->load_api_key() );
+	}
 }

--- a/tests/test-wp-performance-wizard.php
+++ b/tests/test-wp-performance-wizard.php
@@ -1,36 +1,49 @@
 <?php
 /**
- * Unit tests for WP_Performance_Wizard::get_api_key.
+ * Unit tests for the AI agent base class key resolution via the Connectors API.
  *
  * @package wp-performance-wizard
  */
 
 use PHPUnit\Framework\TestCase;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	define( 'ABSPATH', '/' );
-}
+require_once __DIR__ . '/bootstrap.php';
 
-require_once dirname( __DIR__ ) . '/includes/class-wp-performance-wizard.php';
-
+/**
+ * Covers Performance_Wizard_AI_Agent_Base::load_api_key().
+ */
 class WP_Performance_Wizard_Test extends TestCase {
 
-	public function testGetApiKey(): void {
-		global $wp_filesystem;
+	/**
+	 * Reset option store and relevant env vars before each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['wp_performance_wizard_test_options'] = array();
+		putenv( 'GEMINI_API_KEY' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv
+	}
 
-		$wp_filesystem = $this->createMock( 'WP_Filesystem_Base' );
+	public function testReturnsEmptyStringWhenConnectorIdMissing(): void {
+		$agent = new Performance_Wizard_AI_Agent_Base();
+		$this->assertSame( '', $agent->load_api_key() );
+	}
 
-		$mock_key_data = '{"apikey": "test_api_key"}';
+	public function testFallsBackToConnectorOption(): void {
+		$GLOBALS['wp_performance_wizard_test_options']['connectors_ai_gemini_api_key'] = 'option-key';
 
-		$wp_filesystem->method( 'get_contents' )
-			->willReturn( $mock_key_data );
+		$agent = new Performance_Wizard_AI_Agent_Base();
+		$agent->set_connector_id( 'gemini' );
 
-		$pw      = new WP_Performance_Wizard();
-		$api_key = $pw->get_api_key( 'Gemini' );
+		$this->assertSame( 'option-key', $agent->load_api_key() );
+	}
 
-		$this->assertEquals( 'test_api_key', $api_key );
+	public function testEnvironmentVariableBeatsOption(): void {
+		$GLOBALS['wp_performance_wizard_test_options']['connectors_ai_gemini_api_key'] = 'option-key';
+		putenv( 'GEMINI_API_KEY=env-key' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv
 
-		$api_key_empty = $pw->get_api_key( '' );
-		$this->assertEquals( '', $api_key_empty );
+		$agent = new Performance_Wizard_AI_Agent_Base();
+		$agent->set_connector_id( 'gemini' );
+
+		$this->assertSame( 'env-key', $agent->load_api_key() );
 	}
 }

--- a/wp-performance-wizard.php
+++ b/wp-performance-wizard.php
@@ -3,13 +3,13 @@
  * Plugin Name: WP Performance Wizard
  * Plugin URI: https://github.com/adamsilverstein/wp-performance-wizard
  * Description: A plugin that uses AI to help you optimize your WordPress site for performance.
- * Version: 1.3.1
+ * Version: 2.0.0
  * Author: Adam Silverstein, Google
  * Author URI: https://github.com/adamsilverstein
  * License: GPLv2 or later
  * Text Domain: wp-performance-wizard
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Requires at least: 6.0
+ * Requires at least: 7.0
  * Requires PHP: 7.4
  *
  * @package wp-performance-wizard
@@ -18,6 +18,42 @@
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
+}
+
+/**
+ * Minimum WordPress version required.
+ *
+ * Tied to the Connectors API, which ships in WordPress 7.0.
+ */
+define( 'WP_PERFORMANCE_WIZARD_MIN_WP_VERSION', '7.0' );
+
+/**
+ * Check that the WordPress version satisfies the plugin's minimum.
+ *
+ * @return bool True if the current WordPress version is supported.
+ */
+function wp_performance_wizard_is_supported_wp(): bool {
+	global $wp_version;
+	return version_compare( (string) $wp_version, WP_PERFORMANCE_WIZARD_MIN_WP_VERSION, '>=' );
+}
+
+/**
+ * Render an admin notice when the WordPress version is too old.
+ */
+function wp_performance_wizard_unsupported_wp_notice(): void {
+	echo '<div class="notice notice-error"><p>';
+	printf(
+		/* translators: %s: minimum WordPress version */
+		esc_html__( 'WP Performance Wizard requires WordPress %s or later because it uses the core Connectors API. Please upgrade WordPress to continue using the plugin.', 'wp-performance-wizard' ),
+		esc_html( WP_PERFORMANCE_WIZARD_MIN_WP_VERSION )
+	);
+	echo '</p></div>';
+}
+
+// Bail early on unsupported WordPress versions; show a notice instead.
+if ( ! wp_performance_wizard_is_supported_wp() ) {
+	add_action( 'admin_notices', 'wp_performance_wizard_unsupported_wp_notice' );
+	return;
 }
 
 // Load the plugin.


### PR DESCRIPTION
Closes #55.

## Summary
- Require WordPress 7.0 and bail with an admin notice on older versions.
- Replace the plugin's bespoke API key UI, encryption, and JSON-file storage with the core Connectors API that ships in WordPress 7.0.
- Register \`gemini\`, \`anthropic\`, and \`openai\` connectors via \`wp_connectors_init\` (only when another plugin has not already registered them), so users configure credentials entirely on the core Connectors admin screen.
- Resolve credentials through the documented Connectors priority: \`{PROVIDER}_API_KEY\` env var → PHP constant → \`connectors_ai_{id}_api_key\` option.

## Notable changes
- New \`Performance_Wizard_Connectors\` class boots AI connector registration.
- \`Performance_Wizard_AI_Agent_Base\` loses ~190 lines of encryption/save/status-message code; agents now declare a \`connector_id\` and inherit the shared loader.
- Gemini, Claude, and ChatGPT agent classes drop \`add_submenu_page\`, \`render_admin_page\`, \`handle_api_key_submission\`, and their \`admin_post\` hooks.
- The "no AI models configured" notice now links to a filterable core Connectors admin URL.
- README rewritten for the Connectors-based flow; plugin bumped to 2.0.0.
- Unit tests refactored with a small bootstrap to cover the new env/option resolution order.

## Test plan
- [ ] PHPCS (\`composer run lint\`) passes locally and in CI.
- [ ] PHPStan (\`composer run phpstan\`) passes locally and in CI.
- [ ] On WordPress < 7.0, the plugin shows the admin notice and does not activate its menus.
- [ ] On WordPress 7.0+, configuring a Gemini / Anthropic / OpenAI connector on the Connectors screen makes that model available in the Performance Wizard admin page.
- [ ] Defining \`GEMINI_API_KEY\`, \`ANTHROPIC_API_KEY\`, or \`OPENAI_API_KEY\` as an environment variable or PHP constant takes precedence over the stored option.
- [ ] No \`wp-performance-wizard-gemini\` / \`-claude\` / \`-chatgpt\` submenu pages remain in wp-admin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI provider setup now integrates with WordPress 7.0+ Connectors API; providers surface as selectable models in the wizard.
  * Credentials may be supplied via environment variables or PHP constants.

* **Documentation**
  * Updated README with Requirements, provider-connection workflow, and usage instructions.

* **Chores**
  * Plugin bumped to 2.0.0; minimum WP 7.0 and PHP 7.4+.
  * Removed built-in API key admin UI in favor of Connectors.

* **Tests**
  * Added test bootstrap and updated tests to cover connector-based credential resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->