### PR TITLE
Integrate expert web-quality and WordPress skills as analysis context

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Bundled skills live under `includes/skills/` and map to steps as follows:
 * **HTML** → `best-practices`, `performance`
 * **Script Attribution** → `performance`, `best-practices`
 * **Themes and Plugins** → `wp-performance`, `wp-plugin-development`
-* **Summary step** → `core-web-vitals`, `wp-performance`
+* **Summarize Results** → `core-web-vitals`, `wp-performance`
 
 Sources:
 * [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills) — MIT

--- a/README.md
+++ b/README.md
@@ -70,3 +70,21 @@ The performance wizard will analyze the following data sources to make its recom
 * **Site HTML:** This analyzes the source code of front-end page loads for the home page, a single post, and an archive page, looking for potential performance bottlenecks in the HTML structure itself, such as excessive DOM size or render-blocking resources.
 * **Script Attribution:** This identifies all scripts loaded on the site and attributes them to their source (plugin, theme, or core). This helps pinpoint scripts that might be contributing to slow page load times.
 * **Plugins / Theme:** This gathers information about active plugins and the active theme, including metadata. This data can help identify potential performance issues related to specific plugins or themes.
+
+## Expert reference skills
+Each analysis step is augmented with bundled expert playbooks so recommendations are grounded in well-known patterns rather than relying solely on the model's prior knowledge.
+
+Bundled skills live under `includes/skills/` and map to steps as follows:
+* **Lighthouse** → `performance`, `core-web-vitals`
+* **HTML** → `best-practices`, `performance`
+* **Script Attribution** → `performance`, `best-practices`
+* **Themes and Plugins** → `wp-performance`, `wp-plugin-development`
+* **Summary step** → `core-web-vitals`, `wp-performance`
+
+Sources:
+* [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills) — MIT
+* [WordPress/agent-skills](https://github.com/WordPress/agent-skills) — GPL-2.0-or-later
+
+Attribution and the pinned upstream commits are recorded in [`includes/skills/NOTICE.md`](includes/skills/NOTICE.md).
+
+The step-to-skill mapping can be filtered via `wp_performance_wizard_skill_slugs_for_step`, and the feature can be toggled in **Performance Wizard → Settings** or with the `wp_performance_wizard_use_expert_skills` filter.

--- a/includes/class-performance-wizard-analysis-plan.php
+++ b/includes/class-performance-wizard-analysis-plan.php
@@ -158,6 +158,13 @@ class Performance_Wizard_Analysis_Plan {
 	private $wizard;
 
 	/**
+	 * Skills provider used to inject expert reference material into prompts.
+	 *
+	 * @var Performance_Wizard_Skills
+	 */
+	private $skills;
+
+	/**
 	 * Helper to get the current step.
 	 *
 	 * @return int The current step.
@@ -174,8 +181,16 @@ class Performance_Wizard_Analysis_Plan {
 	public function __construct( WP_Performance_Wizard $wizard ) {
 		$this->wizard = $wizard;
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-data-source-base.php';
+		$this->skills = new Performance_Wizard_Skills();
 		$this->set_up_plan();
 		add_option( $this->wizard->get_option_name(), array() );
+	}
+
+	/**
+	 * Get the skills provider.
+	 */
+	public function get_skills(): Performance_Wizard_Skills {
+		return $this->skills;
 	}
 
 	/**
@@ -344,6 +359,25 @@ Finally, based on the data collected and recommendations so far, provide two uni
 		}
 		array_push( $prompts, $prompt );
 		array_push( $prompts_for_display, $prompt );
+
+		// Inject expert skill reference material so recommendations are grounded in
+		// well-known patterns (Core Web Vitals, WP-CLI diagnostics, 10up best practices, etc.).
+		$step_key = '';
+		if ( is_object( $data_source ) && method_exists( $data_source, 'get_name' ) ) {
+			$step_key = $data_source->get_name();
+		} elseif ( isset( $action['title'] ) ) {
+			$step_key = (string) $action['title'];
+		}
+		if ( '' !== $step_key ) {
+			$reference_prompt = $this->skills->build_reference_prompt( $step_key );
+			if ( '' !== $reference_prompt ) {
+				array_push( $prompts, $reference_prompt );
+				array_push(
+					$prompts_for_display,
+					'<em>' . esc_html__( 'Reference guidance from bundled expert skills was included in the prompt.', 'wp-performance-wizard' ) . '</em>'
+				);
+			}
+		}
 
 		$prompt = $data_source->get_prompt();
 		if ( '' !== $prompt ) {

--- a/includes/class-performance-wizard-settings-page.php
+++ b/includes/class-performance-wizard-settings-page.php
@@ -56,6 +56,7 @@ class Performance_Wizard_Settings_Page {
 		$defaults = array(
 			'collect_plugin_sources'  => false,
 			'plugin_source_languages' => array( 'php' ),
+			'use_expert_skills'       => true,
 		);
 		if ( ! is_array( $stored ) ) {
 			$stored = array();
@@ -115,6 +116,7 @@ class Performance_Wizard_Settings_Page {
 		$options            = self::get_options();
 		$collect_enabled    = (bool) $options['collect_plugin_sources'];
 		$selected_languages = (array) $options['plugin_source_languages'];
+		$skills_enabled     = (bool) $options['use_expert_skills'];
 
 		$notice = isset( $_GET['info'] ) ? sanitize_key( wp_unslash( $_GET['info'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
@@ -159,6 +161,23 @@ class Performance_Wizard_Settings_Page {
 
 		echo '</tbody></table>';
 
+		echo '<h2>' . esc_html__( 'Expert Reference Skills', 'wp-performance-wizard' ) . '</h2>';
+		echo '<p>';
+		printf(
+			/* translators: 1: link to addyosmani/web-quality-skills, 2: link to WordPress/agent-skills */
+			esc_html__( 'When enabled, each analysis step includes bundled expert reference material from %1$s (MIT) and %2$s (GPL-2.0-or-later) so recommendations stay grounded in well-known web performance and WordPress best practices. This adds some tokens to each prompt. Disable to reduce cost or if your chosen model already includes equivalent guidance.', 'wp-performance-wizard' ),
+			'<a href="https://github.com/addyosmani/web-quality-skills" target="_blank" rel="noreferrer noopener">addyosmani/web-quality-skills</a>',
+			'<a href="https://github.com/WordPress/agent-skills" target="_blank" rel="noreferrer noopener">WordPress/agent-skills</a>'
+		);
+		echo '</p>';
+		echo '<table class="form-table" role="presentation"><tbody>';
+		echo '<tr><th scope="row">' . esc_html__( 'Include expert skills', 'wp-performance-wizard' ) . '</th><td>';
+		echo '<label><input type="checkbox" name="use_expert_skills" value="1"' . checked( $skills_enabled, true, false ) . '> ';
+		echo esc_html__( 'Inject expert reference skills as context in each analysis step.', 'wp-performance-wizard' );
+		echo '</label>';
+		echo '</td></tr>';
+		echo '</tbody></table>';
+
 		submit_button();
 		echo '</form>';
 		echo '</div>';
@@ -196,9 +215,12 @@ class Performance_Wizard_Settings_Page {
 			$submitted_languages = array( 'php' );
 		}
 
+		$skills_enabled = isset( $_POST['use_expert_skills'] );
+
 		$options                            = self::get_options();
 		$options['collect_plugin_sources']  = $collect;
 		$options['plugin_source_languages'] = array_values( array_unique( $submitted_languages ) );
+		$options['use_expert_skills']       = $skills_enabled;
 
 		update_option( self::OPTION_NAME, $options );
 

--- a/includes/class-performance-wizard-skills.php
+++ b/includes/class-performance-wizard-skills.php
@@ -127,10 +127,13 @@ class Performance_Wizard_Skills {
 		/**
 		 * Filters the skill slugs selected for a given analysis step.
 		 *
-		 * @param string[] $slugs    The default skill slugs for this step.
-		 * @param string   $step_key The step title or data source name.
+		 * @param mixed  $slugs    The default skill slugs for this step (string[]).
+		 * @param string $step_key The step title or data source name.
 		 */
 		$filtered = apply_filters( 'wp_performance_wizard_skill_slugs_for_step', $slugs, $step_key );
+		if ( ! is_array( $filtered ) ) {
+			return array();
+		}
 		// Drop unknown slugs so callers can trust the list.
 		return array_values( array_intersect( array_keys( $this->skills ), $filtered ) );
 	}

--- a/includes/class-performance-wizard-skills.php
+++ b/includes/class-performance-wizard-skills.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Expert skills provider for the Performance Wizard.
+ *
+ * @package wp-performance-wizard
+ */
+
+/**
+ * Loads vendored "agent skill" Markdown files (see includes/skills/NOTICE.md)
+ * and maps analysis steps to the skills whose guidance should be included as
+ * reference context in the prompt sent to the AI agent.
+ *
+ * This grounds recommendations in well-known web performance and WordPress
+ * playbooks (web.dev Core Web Vitals, 10up best practices, WP-CLI diagnostics,
+ * etc.) rather than relying solely on the model's prior knowledge.
+ */
+class Performance_Wizard_Skills {
+
+	/**
+	 * Registry of available skills keyed by slug.
+	 *
+	 * Each entry: label, source repo, license, path relative to the skills directory.
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	private $skills = array(
+		'performance'           => array(
+			'label'   => 'Web performance (Lighthouse & Core Web Vitals)',
+			'source'  => 'addyosmani/web-quality-skills',
+			'license' => 'MIT',
+			'path'    => 'web-quality/performance.md',
+		),
+		'core-web-vitals'       => array(
+			'label'   => 'Core Web Vitals (LCP, INP, CLS)',
+			'source'  => 'addyosmani/web-quality-skills',
+			'license' => 'MIT',
+			'path'    => 'web-quality/core-web-vitals.md',
+		),
+		'best-practices'        => array(
+			'label'   => 'Modern web best practices',
+			'source'  => 'addyosmani/web-quality-skills',
+			'license' => 'MIT',
+			'path'    => 'web-quality/best-practices.md',
+		),
+		'wp-performance'        => array(
+			'label'   => 'WordPress performance (backend)',
+			'source'  => 'WordPress/agent-skills',
+			'license' => 'GPL-2.0-or-later',
+			'path'    => 'wordpress/wp-performance.md',
+		),
+		'wp-plugin-development' => array(
+			'label'   => 'WordPress plugin development',
+			'source'  => 'WordPress/agent-skills',
+			'license' => 'GPL-2.0-or-later',
+			'path'    => 'wordpress/wp-plugin-development.md',
+		),
+	);
+
+	/**
+	 * Map analysis step titles (or data source names) to the slugs of skills
+	 * whose content should be injected as reference context.
+	 *
+	 * Keys are matched against either the step title or the data source name.
+	 *
+	 * @var array<string, string[]>
+	 */
+	private $step_skill_map = array(
+		'Lighthouse'         => array( 'performance', 'core-web-vitals' ),
+		'HTML'               => array( 'best-practices', 'performance' ),
+		'Script Attribution' => array( 'performance', 'best-practices' ),
+		'Themes and Plugins' => array( 'wp-performance', 'wp-plugin-development' ),
+		'Summarize Results'  => array( 'core-web-vitals', 'wp-performance' ),
+	);
+
+	/**
+	 * Absolute path to the skills directory.
+	 *
+	 * @var string
+	 */
+	private $base_path;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->base_path = plugin_dir_path( __FILE__ ) . 'skills/';
+	}
+
+	/**
+	 * Whether skill-based context injection is enabled.
+	 *
+	 * Filterable via `wp_performance_wizard_use_expert_skills`. Defaults to
+	 * the setting stored on the settings page (default: enabled).
+	 */
+	public static function is_enabled(): bool {
+		$options = Performance_Wizard_Settings_Page::get_options();
+		$enabled = array_key_exists( 'use_expert_skills', $options ) ? (bool) $options['use_expert_skills'] : true;
+		/**
+		 * Filters whether bundled expert skill guidance is added to analysis prompts.
+		 *
+		 * @param bool $enabled Whether expert skill context is enabled.
+		 */
+		return apply_filters( 'wp_performance_wizard_use_expert_skills', $enabled );
+	}
+
+	/**
+	 * Get the skill registry.
+	 *
+	 * @return array<string, array<string, string>>
+	 */
+	public function get_skills(): array {
+		return $this->skills;
+	}
+
+	/**
+	 * Return the slugs of the skills whose content should be included for a given step.
+	 *
+	 * @param string $step_key The step title or data source name.
+	 *
+	 * @return string[] Slugs of matching skills. Empty if no mapping exists.
+	 */
+	public function get_skill_slugs_for_step( string $step_key ): array {
+		$slugs = array();
+		if ( isset( $this->step_skill_map[ $step_key ] ) ) {
+			$slugs = $this->step_skill_map[ $step_key ];
+		}
+		/**
+		 * Filters the skill slugs selected for a given analysis step.
+		 *
+		 * @param string[] $slugs    The default skill slugs for this step.
+		 * @param string   $step_key The step title or data source name.
+		 */
+		$filtered = apply_filters( 'wp_performance_wizard_skill_slugs_for_step', $slugs, $step_key );
+		// Drop unknown slugs so callers can trust the list.
+		return array_values( array_intersect( array_keys( $this->skills ), $filtered ) );
+	}
+
+	/**
+	 * Load the Markdown content of a skill.
+	 *
+	 * @param string $slug Skill slug from the registry.
+	 *
+	 * @return string Skill content, or empty string if the skill or its file is missing.
+	 */
+	public function get_skill_content( string $slug ): string {
+		if ( ! isset( $this->skills[ $slug ] ) ) {
+			return '';
+		}
+		$path = $this->base_path . $this->skills[ $slug ]['path'];
+		if ( ! file_exists( $path ) || ! is_readable( $path ) ) {
+			return '';
+		}
+		$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a bundled read-only file.
+		return false === $contents ? '' : $contents;
+	}
+
+	/**
+	 * Build the combined reference-context prompt for a step.
+	 *
+	 * Returns an empty string if skills are disabled, no skills map to the
+	 * step, or none of the mapped skills have readable content.
+	 *
+	 * @param string $step_key The step title or data source name.
+	 *
+	 * @return string A single prompt string prefixed with a short framing note,
+	 *                ready to be appended to the step's prompt array.
+	 */
+	public function build_reference_prompt( string $step_key ): string {
+		if ( ! self::is_enabled() ) {
+			return '';
+		}
+
+		$slugs = $this->get_skill_slugs_for_step( $step_key );
+		if ( 0 === count( $slugs ) ) {
+			return '';
+		}
+
+		$sections = array();
+		foreach ( $slugs as $slug ) {
+			$content = trim( $this->get_skill_content( $slug ) );
+			if ( '' === $content ) {
+				continue;
+			}
+			$label      = $this->skills[ $slug ]['label'];
+			$source     = $this->skills[ $slug ]['source'];
+			$sections[] = "### Reference skill: {$label} (source: {$source})\n\n{$content}";
+		}
+
+		if ( 0 === count( $sections ) ) {
+			return '';
+		}
+
+		$header = 'The following expert reference material is provided to ground your analysis in well-known web performance and WordPress best practices. Use it to inform your recommendations, cite specific patterns when relevant, and avoid generic advice. Do not echo this material back to the user.';
+
+		return $header . "\n\n" . implode( "\n\n---\n\n", $sections );
+	}
+}

--- a/includes/class-performance-wizard-skills.php
+++ b/includes/class-performance-wizard-skills.php
@@ -134,8 +134,14 @@ class Performance_Wizard_Skills {
 		if ( ! is_array( $filtered ) ) {
 			return array();
 		}
-		// Drop unknown slugs so callers can trust the list.
-		return array_values( array_intersect( array_keys( $this->skills ), $filtered ) );
+		// Drop non-strings and unknown slugs so callers can trust the list.
+		$valid = array();
+		foreach ( $filtered as $slug ) {
+			if ( is_string( $slug ) && isset( $this->skills[ $slug ] ) && ! in_array( $slug, $valid, true ) ) {
+				$valid[] = $slug;
+			}
+		}
+		return $valid;
 	}
 
 	/**
@@ -154,7 +160,12 @@ class Performance_Wizard_Skills {
 			return '';
 		}
 		$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a bundled read-only file.
-		return false === $contents ? '' : $contents;
+		if ( false === $contents ) {
+			return '';
+		}
+		// Strip leading YAML frontmatter block so it doesn't leak into the prompt.
+		$stripped = preg_replace( '/\A---\R.*?\R---\R/s', '', $contents, 1 );
+		return is_string( $stripped ) ? trim( $stripped ) : trim( $contents );
 	}
 
 	/**

--- a/includes/class-wp-performance-wizard.php
+++ b/includes/class-wp-performance-wizard.php
@@ -173,6 +173,7 @@ class WP_Performance_Wizard {
 		// Load all required files.
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-admin-page.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-settings-page.php';
+		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-skills.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-analysis-plan.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-rest-api.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-ai-agent-base.php';

--- a/includes/skills/NOTICE.md
+++ b/includes/skills/NOTICE.md
@@ -1,0 +1,37 @@
+# Bundled expert skills
+
+The Markdown files under this directory are vendored "agent skills" — short,
+authoritative playbooks used as reference context for the AI agents that back
+the Performance Wizard. They were copied verbatim from upstream sources and
+are redistributed under their original licenses.
+
+## Sources
+
+### `web-quality/`
+
+Copied from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills)
+at commit `fed9617111260e19f4f54b72a2874a3f3de8ff94`.
+
+- `web-quality/performance.md` — from `skills/performance/SKILL.md`
+- `web-quality/core-web-vitals.md` — from `skills/core-web-vitals/SKILL.md`
+- `web-quality/best-practices.md` — from `skills/best-practices/SKILL.md`
+
+License: **MIT** — Copyright (c) 2026 Addy Osmani. See
+<https://github.com/addyosmani/web-quality-skills/blob/main/LICENSE>.
+
+### `wordpress/`
+
+Copied from [WordPress/agent-skills](https://github.com/WordPress/agent-skills)
+at commit `c5c0697b120ec00e8fcf6a265f161c61dbc2581c`.
+
+- `wordpress/wp-performance.md` — from `skills/wp-performance/SKILL.md`
+- `wordpress/wp-plugin-development.md` — from `skills/wp-plugin-development/SKILL.md`
+
+License: **GPL-2.0-or-later** — Copyright (C) 2026 WordPress Contributors. See
+<https://github.com/WordPress/agent-skills/blob/trunk/LICENSE>.
+
+## Refreshing
+
+To refresh these files to a newer upstream version, re-copy from the source
+repositories and update the commit SHAs above. Prefer verbatim copies so
+attribution stays clean.

--- a/includes/skills/NOTICE.md
+++ b/includes/skills/NOTICE.md
@@ -17,7 +17,7 @@ at commit `fed9617111260e19f4f54b72a2874a3f3de8ff94`.
 - `web-quality/best-practices.md` — from `skills/best-practices/SKILL.md`
 
 License: **MIT** — Copyright (c) 2026 Addy Osmani. See
-<https://github.com/addyosmani/web-quality-skills/blob/main/LICENSE>.
+<https://github.com/addyosmani/web-quality-skills/blob/fed9617111260e19f4f54b72a2874a3f3de8ff94/LICENSE>.
 
 ### `wordpress/`
 
@@ -28,7 +28,7 @@ at commit `c5c0697b120ec00e8fcf6a265f161c61dbc2581c`.
 - `wordpress/wp-plugin-development.md` — from `skills/wp-plugin-development/SKILL.md`
 
 License: **GPL-2.0-or-later** — Copyright (C) 2026 WordPress Contributors. See
-<https://github.com/WordPress/agent-skills/blob/trunk/LICENSE>.
+<https://github.com/WordPress/agent-skills/blob/c5c0697b120ec00e8fcf6a265f161c61dbc2581c/LICENSE>.
 
 ## Refreshing
 

--- a/includes/skills/web-quality/best-practices.md
+++ b/includes/skills/web-quality/best-practices.md
@@ -1,0 +1,583 @@
+---
+name: best-practices
+description: Apply modern web development best practices for security, compatibility, and code quality. Use when asked to "apply best practices", "security audit", "modernize code", "code quality review", or "check for vulnerabilities".
+license: MIT
+metadata:
+  author: web-quality-skills
+  version: "1.0"
+---
+
+# Best practices
+
+Modern web development standards based on Lighthouse best practices audits. Covers security, browser compatibility, and code quality patterns.
+
+## Security
+
+### HTTPS everywhere
+
+**Enforce HTTPS:**
+```html
+<!-- ❌ Mixed content -->
+<img src="http://example.com/image.jpg">
+<script src="http://cdn.example.com/script.js"></script>
+
+<!-- ✅ HTTPS only -->
+<img src="https://example.com/image.jpg">
+<script src="https://cdn.example.com/script.js"></script>
+
+<!-- ✅ Protocol-relative (will use page's protocol) -->
+<img src="//example.com/image.jpg">
+```
+
+**HSTS Header:**
+```
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+```
+
+### Content Security Policy (CSP)
+
+```html
+<!-- Basic CSP via meta tag -->
+<meta http-equiv="Content-Security-Policy" 
+      content="default-src 'self'; 
+               script-src 'self' https://trusted-cdn.com; 
+               style-src 'self' 'unsafe-inline';
+               img-src 'self' data: https:;
+               connect-src 'self' https://api.example.com;">
+
+<!-- Better: HTTP header -->
+```
+
+**CSP Header (recommended):**
+```
+Content-Security-Policy: 
+  default-src 'self';
+  script-src 'self' 'nonce-abc123' https://trusted.com;
+  style-src 'self' 'nonce-abc123';
+  img-src 'self' data: https:;
+  connect-src 'self' https://api.example.com;
+  frame-ancestors 'self';
+  base-uri 'self';
+  form-action 'self';
+```
+
+**Using nonces for inline scripts:**
+```html
+<script nonce="abc123">
+  // This inline script is allowed
+</script>
+```
+
+### Security headers
+
+```
+# Prevent clickjacking
+X-Frame-Options: DENY
+
+# Prevent MIME type sniffing
+X-Content-Type-Options: nosniff
+
+# Enable XSS filter (legacy browsers)
+X-XSS-Protection: 1; mode=block
+
+# Control referrer information
+Referrer-Policy: strict-origin-when-cross-origin
+
+# Permissions policy (formerly Feature-Policy)
+Permissions-Policy: geolocation=(), microphone=(), camera=()
+```
+
+### No vulnerable libraries
+
+```bash
+# Check for vulnerabilities
+npm audit
+yarn audit
+
+# Auto-fix when possible
+npm audit fix
+
+# Check specific package
+npm ls lodash
+```
+
+**Keep dependencies updated:**
+```json
+// package.json
+{
+  "scripts": {
+    "audit": "npm audit --audit-level=moderate",
+    "update": "npm update && npm audit fix"
+  }
+}
+```
+
+**Known vulnerable patterns to avoid:**
+```javascript
+// ❌ Prototype pollution vulnerable patterns
+Object.assign(target, userInput);
+_.merge(target, userInput);
+
+// ✅ Safer alternatives
+const safeData = JSON.parse(JSON.stringify(userInput));
+```
+
+### Input sanitization
+
+```javascript
+// ❌ XSS vulnerable
+element.innerHTML = userInput;
+document.write(userInput);
+
+// ✅ Safe text content
+element.textContent = userInput;
+
+// ✅ If HTML needed, sanitize
+import DOMPurify from 'dompurify';
+element.innerHTML = DOMPurify.sanitize(userInput);
+```
+
+### Secure cookies
+
+```javascript
+// ❌ Insecure cookie
+document.cookie = "session=abc123";
+
+// ✅ Secure cookie (server-side)
+Set-Cookie: session=abc123; Secure; HttpOnly; SameSite=Strict; Path=/
+```
+
+---
+
+## Browser compatibility
+
+### Doctype declaration
+
+```html
+<!-- ❌ Missing or invalid doctype -->
+<HTML>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
+
+<!-- ✅ HTML5 doctype -->
+<!DOCTYPE html>
+<html lang="en">
+```
+
+### Character encoding
+
+```html
+<!-- ❌ Missing or late charset -->
+<html>
+<head>
+  <title>Page</title>
+  <meta charset="UTF-8">
+</head>
+
+<!-- ✅ Charset as first element in head -->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Page</title>
+</head>
+```
+
+### Viewport meta tag
+
+```html
+<!-- ❌ Missing viewport -->
+<head>
+  <title>Page</title>
+</head>
+
+<!-- ✅ Responsive viewport -->
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Page</title>
+</head>
+```
+
+### Feature detection
+
+```javascript
+// ❌ Browser detection (brittle)
+if (navigator.userAgent.includes('Chrome')) {
+  // Chrome-specific code
+}
+
+// ✅ Feature detection
+if ('IntersectionObserver' in window) {
+  // Use IntersectionObserver
+} else {
+  // Fallback
+}
+
+// ✅ Using @supports in CSS
+@supports (display: grid) {
+  .container {
+    display: grid;
+  }
+}
+
+@supports not (display: grid) {
+  .container {
+    display: flex;
+  }
+}
+```
+
+### Polyfills (when needed)
+
+```html
+<!-- Load polyfills conditionally -->
+<script>
+  if (!('fetch' in window)) {
+    document.write('<script src="/polyfills/fetch.js"><\/script>');
+  }
+</script>
+
+<!-- Or use polyfill.io -->
+<script src="https://polyfill.io/v3/polyfill.min.js?features=fetch,IntersectionObserver"></script>
+```
+
+---
+
+## Deprecated APIs
+
+### Avoid these
+
+```javascript
+// ❌ document.write (blocks parsing)
+document.write('<script src="..."></script>');
+
+// ✅ Dynamic script loading
+const script = document.createElement('script');
+script.src = '...';
+document.head.appendChild(script);
+
+// ❌ Synchronous XHR (blocks main thread)
+const xhr = new XMLHttpRequest();
+xhr.open('GET', url, false); // false = synchronous
+
+// ✅ Async fetch
+const response = await fetch(url);
+
+// ❌ Application Cache (deprecated)
+<html manifest="cache.manifest">
+
+// ✅ Service Workers
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js');
+}
+```
+
+### Event listener passive
+
+```javascript
+// ❌ Non-passive touch/wheel (may block scrolling)
+element.addEventListener('touchstart', handler);
+element.addEventListener('wheel', handler);
+
+// ✅ Passive listeners (allows smooth scrolling)
+element.addEventListener('touchstart', handler, { passive: true });
+element.addEventListener('wheel', handler, { passive: true });
+
+// ✅ If you need preventDefault, be explicit
+element.addEventListener('touchstart', handler, { passive: false });
+```
+
+---
+
+## Console & errors
+
+### No console errors
+
+```javascript
+// ❌ Errors in production
+console.log('Debug info'); // Remove in production
+throw new Error('Unhandled'); // Catch all errors
+
+// ✅ Proper error handling
+try {
+  riskyOperation();
+} catch (error) {
+  // Log to error tracking service
+  errorTracker.captureException(error);
+  // Show user-friendly message
+  showErrorMessage('Something went wrong. Please try again.');
+}
+```
+
+### Error boundaries (React)
+
+```jsx
+class ErrorBoundary extends React.Component {
+  state = { hasError: false };
+  
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+  
+  componentDidCatch(error, info) {
+    errorTracker.captureException(error, { extra: info });
+  }
+  
+  render() {
+    if (this.state.hasError) {
+      return <FallbackUI />;
+    }
+    return this.props.children;
+  }
+}
+
+// Usage
+<ErrorBoundary>
+  <App />
+</ErrorBoundary>
+```
+
+### Global error handler
+
+```javascript
+// Catch unhandled errors
+window.addEventListener('error', (event) => {
+  errorTracker.captureException(event.error);
+});
+
+// Catch unhandled promise rejections
+window.addEventListener('unhandledrejection', (event) => {
+  errorTracker.captureException(event.reason);
+});
+```
+
+---
+
+## Source maps
+
+### Production configuration
+
+```javascript
+// ❌ Source maps exposed in production
+// webpack.config.js
+module.exports = {
+  devtool: 'source-map', // Exposes source code
+};
+
+// ✅ Hidden source maps (uploaded to error tracker)
+module.exports = {
+  devtool: 'hidden-source-map',
+};
+
+// ✅ Or no source maps in production
+module.exports = {
+  devtool: process.env.NODE_ENV === 'production' ? false : 'source-map',
+};
+```
+
+---
+
+## Performance best practices
+
+### Avoid blocking patterns
+
+```javascript
+// ❌ Blocking script
+<script src="heavy-library.js"></script>
+
+// ✅ Deferred script
+<script defer src="heavy-library.js"></script>
+
+// ❌ Blocking CSS import
+@import url('other-styles.css');
+
+// ✅ Link tags (parallel loading)
+<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="other-styles.css">
+```
+
+### Efficient event handlers
+
+```javascript
+// ❌ Handler on every element
+items.forEach(item => {
+  item.addEventListener('click', handleClick);
+});
+
+// ✅ Event delegation
+container.addEventListener('click', (e) => {
+  if (e.target.matches('.item')) {
+    handleClick(e);
+  }
+});
+```
+
+### Memory management
+
+```javascript
+// ❌ Memory leak (never removed)
+const handler = () => { /* ... */ };
+window.addEventListener('resize', handler);
+
+// ✅ Cleanup when done
+const handler = () => { /* ... */ };
+window.addEventListener('resize', handler);
+
+// Later, when component unmounts:
+window.removeEventListener('resize', handler);
+
+// ✅ Using AbortController
+const controller = new AbortController();
+window.addEventListener('resize', handler, { signal: controller.signal });
+
+// Cleanup:
+controller.abort();
+```
+
+---
+
+## Code quality
+
+### Valid HTML
+
+```html
+<!-- ❌ Invalid HTML -->
+<div id="header">
+<div id="header"> <!-- Duplicate ID -->
+
+<ul>
+  <div>Item</div> <!-- Invalid child -->
+</ul>
+
+<a href="/"><button>Click</button></a> <!-- Invalid nesting -->
+
+<!-- ✅ Valid HTML -->
+<header id="site-header">
+</header>
+
+<ul>
+  <li>Item</li>
+</ul>
+
+<a href="/" class="button">Click</a>
+```
+
+### Semantic HTML
+
+```html
+<!-- ❌ Non-semantic -->
+<div class="header">
+  <div class="nav">
+    <div class="nav-item">Home</div>
+  </div>
+</div>
+<div class="main">
+  <div class="article">
+    <div class="title">Headline</div>
+  </div>
+</div>
+
+<!-- ✅ Semantic HTML5 -->
+<header>
+  <nav>
+    <a href="/">Home</a>
+  </nav>
+</header>
+<main>
+  <article>
+    <h1>Headline</h1>
+  </article>
+</main>
+```
+
+### Image aspect ratios
+
+```html
+<!-- ❌ Distorted images -->
+<img src="photo.jpg" width="300" height="100">
+<!-- If actual ratio is 4:3, this squishes the image -->
+
+<!-- ✅ Preserve aspect ratio -->
+<img src="photo.jpg" width="300" height="225">
+<!-- Actual 4:3 dimensions -->
+
+<!-- ✅ CSS object-fit for flexibility -->
+<img src="photo.jpg" style="width: 300px; height: 200px; object-fit: cover;">
+```
+
+---
+
+## Permissions & privacy
+
+### Request permissions properly
+
+```javascript
+// ❌ Request on page load (bad UX, often denied)
+navigator.geolocation.getCurrentPosition(success, error);
+
+// ✅ Request in context, after user action
+findNearbyButton.addEventListener('click', async () => {
+  // Explain why you need it
+  if (await showPermissionExplanation()) {
+    navigator.geolocation.getCurrentPosition(success, error);
+  }
+});
+```
+
+### Permissions policy
+
+```html
+<!-- Restrict powerful features -->
+<meta http-equiv="Permissions-Policy" 
+      content="geolocation=(), camera=(), microphone=()">
+
+<!-- Or allow for specific origins -->
+<meta http-equiv="Permissions-Policy" 
+      content="geolocation=(self 'https://maps.example.com')">
+```
+
+---
+
+## Audit checklist
+
+### Security (critical)
+- [ ] HTTPS enabled, no mixed content
+- [ ] No vulnerable dependencies (`npm audit`)
+- [ ] CSP headers configured
+- [ ] Security headers present
+- [ ] No exposed source maps
+
+### Compatibility
+- [ ] Valid HTML5 doctype
+- [ ] Charset declared first in head
+- [ ] Viewport meta tag present
+- [ ] No deprecated APIs used
+- [ ] Passive event listeners for scroll/touch
+
+### Code quality
+- [ ] No console errors
+- [ ] Valid HTML (no duplicate IDs)
+- [ ] Semantic HTML elements used
+- [ ] Proper error handling
+- [ ] Memory cleanup in components
+
+### UX
+- [ ] No intrusive interstitials
+- [ ] Permission requests in context
+- [ ] Clear error messages
+- [ ] Appropriate image aspect ratios
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `npm audit` | Dependency vulnerabilities |
+| [SecurityHeaders.com](https://securityheaders.com) | Header analysis |
+| [W3C Validator](https://validator.w3.org) | HTML validation |
+| Lighthouse | Best practices audit |
+| [Observatory](https://observatory.mozilla.org) | Security scan |
+
+## References
+
+- [MDN Web Security](https://developer.mozilla.org/en-US/docs/Web/Security)
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
+- [Web Quality Audit](../web-quality-audit/SKILL.md)

--- a/includes/skills/web-quality/best-practices.md
+++ b/includes/skills/web-quality/best-practices.md
@@ -30,7 +30,8 @@ Modern web development standards based on Lighthouse best practices audits. Cove
 ```
 
 **HSTS Header:**
-```
+
+```http
 Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
 ```
 
@@ -49,7 +50,8 @@ Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
 ```
 
 **CSP Header (recommended):**
-```
+
+```http
 Content-Security-Policy: 
   default-src 'self';
   script-src 'self' 'nonce-abc123' https://trusted.com;
@@ -70,7 +72,7 @@ Content-Security-Policy:
 
 ### Security headers
 
-```
+```http
 # Prevent clickjacking
 X-Frame-Options: DENY
 
@@ -232,7 +234,10 @@ if ('IntersectionObserver' in window) {
 <!-- Load polyfills conditionally -->
 <script>
   if (!('fetch' in window)) {
-    document.write('<script src="/polyfills/fetch.js"><\/script>');
+    const polyfill = document.createElement('script');
+    polyfill.src = '/polyfills/fetch.js';
+    polyfill.defer = true;
+    document.head.appendChild(polyfill);
   }
 </script>
 

--- a/includes/skills/web-quality/best-practices.md
+++ b/includes/skills/web-quality/best-practices.md
@@ -580,4 +580,3 @@ findNearbyButton.addEventListener('click', async () => {
 
 - [MDN Web Security](https://developer.mozilla.org/en-US/docs/Web/Security)
 - [OWASP Top 10](https://owasp.org/www-project-top-ten/)
-- [Web Quality Audit](../web-quality-audit/SKILL.md)

--- a/includes/skills/web-quality/core-web-vitals.md
+++ b/includes/skills/web-quality/core-web-vitals.md
@@ -1,0 +1,441 @@
+---
+name: core-web-vitals
+description: Optimize Core Web Vitals (LCP, INP, CLS) for better page experience and search ranking. Use when asked to "improve Core Web Vitals", "fix LCP", "reduce CLS", "optimize INP", "page experience optimization", or "fix layout shifts".
+license: MIT
+metadata:
+  author: web-quality-skills
+  version: "1.0"
+---
+
+# Core Web Vitals optimization
+
+Targeted optimization for the three Core Web Vitals metrics that affect Google Search ranking and user experience.
+
+## The three metrics
+
+| Metric | Measures | Good | Needs work | Poor |
+|--------|----------|------|------------|------|
+| **LCP** | Loading | ≤ 2.5s | 2.5s – 4s | > 4s |
+| **INP** | Interactivity | ≤ 200ms | 200ms – 500ms | > 500ms |
+| **CLS** | Visual Stability | ≤ 0.1 | 0.1 – 0.25 | > 0.25 |
+
+Google measures at the **75th percentile** — 75% of page visits must meet "Good" thresholds.
+
+---
+
+## LCP: Largest Contentful Paint
+
+LCP measures when the largest visible content element renders. Usually this is:
+- Hero image or video
+- Large text block
+- Background image
+- `<svg>` element
+
+### Common LCP issues
+
+**1. Slow server response (TTFB > 800ms)**
+```
+Fix: CDN, caching, optimized backend, edge rendering
+```
+
+**2. Render-blocking resources**
+```html
+<!-- ❌ Blocks rendering -->
+<link rel="stylesheet" href="/all-styles.css">
+
+<!-- ✅ Critical CSS inlined, rest deferred -->
+<style>/* Critical above-fold CSS */</style>
+<link rel="preload" href="/styles.css" as="style" 
+      onload="this.onload=null;this.rel='stylesheet'">
+```
+
+**3. Slow resource load times**
+```html
+<!-- ❌ No hints, discovered late -->
+<img src="/hero.jpg" alt="Hero">
+
+<!-- ✅ Preloaded with high priority -->
+<link rel="preload" href="/hero.webp" as="image" fetchpriority="high">
+<img src="/hero.webp" alt="Hero" fetchpriority="high">
+```
+
+**4. Client-side rendering delays**
+```javascript
+// ❌ Content loads after JavaScript
+useEffect(() => {
+  fetch('/api/hero-text').then(r => r.json()).then(setHeroText);
+}, []);
+
+// ✅ Server-side or static rendering
+// Use SSR, SSG, or streaming to send HTML with content
+export async function getServerSideProps() {
+  const heroText = await fetchHeroText();
+  return { props: { heroText } };
+}
+```
+
+### LCP optimization checklist
+
+```markdown
+- [ ] TTFB < 800ms (use CDN, edge caching)
+- [ ] LCP image preloaded with fetchpriority="high"
+- [ ] LCP image optimized (WebP/AVIF, correct size)
+- [ ] Critical CSS inlined (< 14KB)
+- [ ] No render-blocking JavaScript in <head>
+- [ ] Fonts don't block text rendering (font-display: swap)
+- [ ] LCP element in initial HTML (not JS-rendered)
+```
+
+### LCP element identification
+```javascript
+// Find your LCP element
+new PerformanceObserver((list) => {
+  const entries = list.getEntries();
+  const lastEntry = entries[entries.length - 1];
+  console.log('LCP element:', lastEntry.element);
+  console.log('LCP time:', lastEntry.startTime);
+}).observe({ type: 'largest-contentful-paint', buffered: true });
+```
+
+---
+
+## INP: Interaction to Next Paint
+
+INP measures responsiveness across ALL interactions (clicks, taps, key presses) during a page visit. It reports the worst interaction (at 98th percentile for high-traffic pages).
+
+### INP breakdown
+
+Total INP = **Input Delay** + **Processing Time** + **Presentation Delay**
+
+| Phase | Target | Optimization |
+|-------|--------|--------------|
+| Input Delay | < 50ms | Reduce main thread blocking |
+| Processing | < 100ms | Optimize event handlers |
+| Presentation | < 50ms | Minimize rendering work |
+
+### Common INP issues
+
+**1. Long tasks blocking main thread**
+```javascript
+// ❌ Long synchronous task
+function processLargeArray(items) {
+  items.forEach(item => expensiveOperation(item));
+}
+
+// ✅ Break into chunks with yielding
+async function processLargeArray(items) {
+  const CHUNK_SIZE = 100;
+  for (let i = 0; i < items.length; i += CHUNK_SIZE) {
+    const chunk = items.slice(i, i + CHUNK_SIZE);
+    chunk.forEach(item => expensiveOperation(item));
+    
+    // Yield to main thread
+    await new Promise(r => setTimeout(r, 0));
+    // Or use scheduler.yield() when available
+  }
+}
+```
+
+**2. Heavy event handlers**
+```javascript
+// ❌ All work in handler
+button.addEventListener('click', () => {
+  // Heavy computation
+  const result = calculateComplexThing();
+  // DOM updates
+  updateUI(result);
+  // Analytics
+  trackEvent('click');
+});
+
+// ✅ Prioritize visual feedback
+button.addEventListener('click', () => {
+  // Immediate visual feedback
+  button.classList.add('loading');
+  
+  // Defer non-critical work
+  requestAnimationFrame(() => {
+    const result = calculateComplexThing();
+    updateUI(result);
+  });
+  
+  // Use requestIdleCallback for analytics
+  requestIdleCallback(() => trackEvent('click'));
+});
+```
+
+**3. Third-party scripts**
+```javascript
+// ❌ Eagerly loaded, blocks interactions
+<script src="https://heavy-widget.com/widget.js"></script>
+
+// ✅ Lazy loaded on interaction or visibility
+const loadWidget = () => {
+  import('https://heavy-widget.com/widget.js')
+    .then(widget => widget.init());
+};
+button.addEventListener('click', loadWidget, { once: true });
+```
+
+**4. Excessive re-renders (React/Vue)**
+```javascript
+// ❌ Re-renders entire tree
+function App() {
+  const [count, setCount] = useState(0);
+  return (
+    <div>
+      <Counter count={count} />
+      <ExpensiveComponent /> {/* Re-renders on every count change */}
+    </div>
+  );
+}
+
+// ✅ Memoized expensive components
+const MemoizedExpensive = React.memo(ExpensiveComponent);
+
+function App() {
+  const [count, setCount] = useState(0);
+  return (
+    <div>
+      <Counter count={count} />
+      <MemoizedExpensive />
+    </div>
+  );
+}
+```
+
+### INP optimization checklist
+
+```markdown
+- [ ] No tasks > 50ms on main thread
+- [ ] Event handlers complete quickly (< 100ms)
+- [ ] Visual feedback provided immediately
+- [ ] Heavy work deferred with requestIdleCallback
+- [ ] Third-party scripts don't block interactions
+- [ ] Debounced input handlers where appropriate
+- [ ] Web Workers for CPU-intensive operations
+```
+
+### INP debugging
+```javascript
+// Identify slow interactions
+new PerformanceObserver((list) => {
+  for (const entry of list.getEntries()) {
+    if (entry.duration > 200) {
+      console.warn('Slow interaction:', {
+        type: entry.name,
+        duration: entry.duration,
+        processingStart: entry.processingStart,
+        processingEnd: entry.processingEnd,
+        target: entry.target
+      });
+    }
+  }
+}).observe({ type: 'event', buffered: true, durationThreshold: 16 });
+```
+
+---
+
+## CLS: Cumulative Layout Shift
+
+CLS measures unexpected layout shifts. A shift occurs when a visible element changes position between frames without user interaction.
+
+**CLS Formula:** `impact fraction × distance fraction`
+
+### Common CLS causes
+
+**1. Images without dimensions**
+```html
+<!-- ❌ Causes layout shift when loaded -->
+<img src="photo.jpg" alt="Photo">
+
+<!-- ✅ Space reserved -->
+<img src="photo.jpg" alt="Photo" width="800" height="600">
+
+<!-- ✅ Or use aspect-ratio -->
+<img src="photo.jpg" alt="Photo" style="aspect-ratio: 4/3; width: 100%;">
+```
+
+**2. Ads, embeds, and iframes**
+```html
+<!-- ❌ Unknown size until loaded -->
+<iframe src="https://ad-network.com/ad"></iframe>
+
+<!-- ✅ Reserve space with min-height -->
+<div style="min-height: 250px;">
+  <iframe src="https://ad-network.com/ad" height="250"></iframe>
+</div>
+
+<!-- ✅ Or use aspect-ratio container -->
+<div style="aspect-ratio: 16/9;">
+  <iframe src="https://youtube.com/embed/..." 
+          style="width: 100%; height: 100%;"></iframe>
+</div>
+```
+
+**3. Dynamically injected content**
+```javascript
+// ❌ Inserts content above viewport
+notifications.prepend(newNotification);
+
+// ✅ Insert below viewport or use transform
+const insertBelow = viewport.bottom < newNotification.top;
+if (insertBelow) {
+  notifications.prepend(newNotification);
+} else {
+  // Animate in without shifting
+  newNotification.style.transform = 'translateY(-100%)';
+  notifications.prepend(newNotification);
+  requestAnimationFrame(() => {
+    newNotification.style.transform = '';
+  });
+}
+```
+
+**4. Web fonts causing FOUT**
+```css
+/* ❌ Font swap shifts text */
+@font-face {
+  font-family: 'Custom';
+  src: url('custom.woff2') format('woff2');
+}
+
+/* ✅ Optional font (no shift if slow) */
+@font-face {
+  font-family: 'Custom';
+  src: url('custom.woff2') format('woff2');
+  font-display: optional;
+}
+
+/* ✅ Or match fallback metrics */
+@font-face {
+  font-family: 'Custom';
+  src: url('custom.woff2') format('woff2');
+  font-display: swap;
+  size-adjust: 105%; /* Match fallback size */
+  ascent-override: 95%;
+  descent-override: 20%;
+}
+```
+
+**5. Animations triggering layout**
+```css
+/* ❌ Animates layout properties */
+.animate {
+  transition: height 0.3s, width 0.3s;
+}
+
+/* ✅ Use transform instead */
+.animate {
+  transition: transform 0.3s;
+}
+.animate.expanded {
+  transform: scale(1.2);
+}
+```
+
+### CLS optimization checklist
+
+```markdown
+- [ ] All images have width/height or aspect-ratio
+- [ ] All videos/embeds have reserved space
+- [ ] Ads have min-height containers
+- [ ] Fonts use font-display: optional or matched metrics
+- [ ] Dynamic content inserted below viewport
+- [ ] Animations use transform/opacity only
+- [ ] No content injected above existing content
+```
+
+### CLS debugging
+```javascript
+// Track layout shifts
+new PerformanceObserver((list) => {
+  for (const entry of list.getEntries()) {
+    if (!entry.hadRecentInput) {
+      console.log('Layout shift:', entry.value);
+      entry.sources?.forEach(source => {
+        console.log('  Shifted element:', source.node);
+        console.log('  Previous rect:', source.previousRect);
+        console.log('  Current rect:', source.currentRect);
+      });
+    }
+  }
+}).observe({ type: 'layout-shift', buffered: true });
+```
+
+---
+
+## Measurement tools
+
+### Lab testing
+- **Chrome DevTools** → Performance panel, Lighthouse
+- **WebPageTest** → Detailed waterfall, filmstrip
+- **Lighthouse CLI** → `npx lighthouse <url>`
+
+### Field data (real users)
+- **Chrome User Experience Report (CrUX)** → BigQuery or API
+- **Search Console** → Core Web Vitals report
+- **web-vitals library** → Send to your analytics
+
+```javascript
+import {onLCP, onINP, onCLS} from 'web-vitals';
+
+function sendToAnalytics({name, value, rating}) {
+  gtag('event', name, {
+    event_category: 'Web Vitals',
+    value: Math.round(name === 'CLS' ? value * 1000 : value),
+    event_label: rating
+  });
+}
+
+onLCP(sendToAnalytics);
+onINP(sendToAnalytics);
+onCLS(sendToAnalytics);
+```
+
+---
+
+## Framework quick fixes
+
+### Next.js
+```jsx
+// LCP: Use next/image with priority
+import Image from 'next/image';
+<Image src="/hero.jpg" priority fill alt="Hero" />
+
+// INP: Use dynamic imports
+const HeavyComponent = dynamic(() => import('./Heavy'), { ssr: false });
+
+// CLS: Image component handles dimensions automatically
+```
+
+### React
+```jsx
+// LCP: Preload in head
+<link rel="preload" href="/hero.jpg" as="image" fetchpriority="high" />
+
+// INP: Memoize and useTransition
+const [isPending, startTransition] = useTransition();
+startTransition(() => setExpensiveState(newValue));
+
+// CLS: Always specify dimensions in img tags
+```
+
+### Vue/Nuxt
+```vue
+<!-- LCP: Use nuxt/image with preload -->
+<NuxtImg src="/hero.jpg" preload loading="eager" />
+
+<!-- INP: Use async components -->
+<component :is="() => import('./Heavy.vue')" />
+
+<!-- CLS: Use aspect-ratio CSS -->
+<img :style="{ aspectRatio: '16/9' }" />
+```
+
+## References
+
+- [web.dev LCP](https://web.dev/articles/lcp)
+- [web.dev INP](https://web.dev/articles/inp)
+- [web.dev CLS](https://web.dev/articles/cls)
+- [Performance skill](../performance/SKILL.md)

--- a/includes/skills/web-quality/core-web-vitals.md
+++ b/includes/skills/web-quality/core-web-vitals.md
@@ -438,4 +438,4 @@ startTransition(() => setExpensiveState(newValue));
 - [web.dev LCP](https://web.dev/articles/lcp)
 - [web.dev INP](https://web.dev/articles/inp)
 - [web.dev CLS](https://web.dev/articles/cls)
-- [Performance skill](../performance/SKILL.md)
+- [Performance skill](./performance.md)

--- a/includes/skills/web-quality/performance.md
+++ b/includes/skills/web-quality/performance.md
@@ -1,0 +1,361 @@
+---
+name: performance
+description: Optimize web performance for faster loading and better user experience. Use when asked to "speed up my site", "optimize performance", "reduce load time", "fix slow loading", "improve page speed", or "performance audit".
+license: MIT
+metadata:
+  author: web-quality-skills
+  version: "1.0"
+---
+
+# Performance optimization
+
+Deep performance optimization based on Lighthouse performance audits. Focuses on loading speed, runtime efficiency, and resource optimization.
+
+## How it works
+
+1. Identify performance bottlenecks in code and assets
+2. Prioritize by impact on Core Web Vitals
+3. Provide specific optimizations with code examples
+4. Measure improvement with before/after metrics
+
+## Performance budget
+
+| Resource | Budget | Rationale |
+|----------|--------|-----------|
+| Total page weight | < 1.5 MB | 3G loads in ~4s |
+| JavaScript (compressed) | < 300 KB | Parsing + execution time |
+| CSS (compressed) | < 100 KB | Render blocking |
+| Images (above-fold) | < 500 KB | LCP impact |
+| Fonts | < 100 KB | FOIT/FOUT prevention |
+| Third-party | < 200 KB | Uncontrolled latency |
+
+## Critical rendering path
+
+### Server response
+* **TTFB < 800ms.** Time to First Byte should be fast. Use CDN, caching, and efficient backends.
+* **Enable compression.** Gzip or Brotli for text assets. Brotli preferred (15-20% smaller).
+* **HTTP/2 or HTTP/3.** Multiplexing reduces connection overhead.
+* **Edge caching.** Cache HTML at CDN edge when possible.
+
+### Resource loading
+
+**Preconnect to required origins:**
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://cdn.example.com" crossorigin>
+```
+
+**Preload critical resources:**
+```html
+<!-- LCP image -->
+<link rel="preload" href="/hero.webp" as="image" fetchpriority="high">
+
+<!-- Critical font -->
+<link rel="preload" href="/font.woff2" as="font" type="font/woff2" crossorigin>
+```
+
+**Defer non-critical CSS:**
+```html
+<!-- Critical CSS inlined -->
+<style>/* Above-fold styles */</style>
+
+<!-- Non-critical CSS -->
+<link rel="preload" href="/styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="/styles.css"></noscript>
+```
+
+### JavaScript optimization
+
+**Defer non-essential scripts:**
+```html
+<!-- Parser-blocking (avoid) -->
+<script src="/critical.js"></script>
+
+<!-- Deferred (preferred) -->
+<script defer src="/app.js"></script>
+
+<!-- Async (for independent scripts) -->
+<script async src="/analytics.js"></script>
+
+<!-- Module (deferred by default) -->
+<script type="module" src="/app.mjs"></script>
+```
+
+**Code splitting patterns:**
+```javascript
+// Route-based splitting
+const Dashboard = lazy(() => import('./Dashboard'));
+
+// Component-based splitting
+const HeavyChart = lazy(() => import('./HeavyChart'));
+
+// Feature-based splitting
+if (user.isPremium) {
+  const PremiumFeatures = await import('./PremiumFeatures');
+}
+```
+
+**Tree shaking best practices:**
+```javascript
+// ❌ Imports entire library
+import _ from 'lodash';
+_.debounce(fn, 300);
+
+// ✅ Imports only what's needed
+import debounce from 'lodash/debounce';
+debounce(fn, 300);
+```
+
+## Image optimization
+
+### Format selection
+| Format | Use case | Browser support |
+|--------|----------|-----------------|
+| AVIF | Photos, best compression | 92%+ |
+| WebP | Photos, good fallback | 97%+ |
+| PNG | Graphics with transparency | Universal |
+| SVG | Icons, logos, illustrations | Universal |
+
+### Responsive images
+```html
+<picture>
+  <!-- AVIF for modern browsers -->
+  <source 
+    type="image/avif"
+    srcset="hero-400.avif 400w,
+            hero-800.avif 800w,
+            hero-1200.avif 1200w"
+    sizes="(max-width: 600px) 100vw, 50vw">
+  
+  <!-- WebP fallback -->
+  <source 
+    type="image/webp"
+    srcset="hero-400.webp 400w,
+            hero-800.webp 800w,
+            hero-1200.webp 1200w"
+    sizes="(max-width: 600px) 100vw, 50vw">
+  
+  <!-- JPEG fallback -->
+  <img 
+    src="hero-800.jpg"
+    srcset="hero-400.jpg 400w,
+            hero-800.jpg 800w,
+            hero-1200.jpg 1200w"
+    sizes="(max-width: 600px) 100vw, 50vw"
+    width="1200" 
+    height="600"
+    alt="Hero image"
+    loading="lazy"
+    decoding="async">
+</picture>
+```
+
+### LCP image priority
+```html
+<!-- Above-fold LCP image: eager loading, high priority -->
+<img 
+  src="hero.webp" 
+  fetchpriority="high"
+  loading="eager"
+  decoding="sync"
+  alt="Hero">
+
+<!-- Below-fold images: lazy loading -->
+<img 
+  src="product.webp" 
+  loading="lazy"
+  decoding="async"
+  alt="Product">
+```
+
+## Font optimization
+
+### Loading strategy
+```css
+/* System font stack as fallback */
+body {
+  font-family: 'Custom Font', -apple-system, BlinkMacSystemFont, 
+               'Segoe UI', Roboto, sans-serif;
+}
+
+/* Prevent invisible text */
+@font-face {
+  font-family: 'Custom Font';
+  src: url('/fonts/custom.woff2') format('woff2');
+  font-display: swap; /* or optional for non-critical */
+  font-weight: 400;
+  font-style: normal;
+  unicode-range: U+0000-00FF; /* Subset to Latin */
+}
+```
+
+### Preloading critical fonts
+```html
+<link rel="preload" href="/fonts/heading.woff2" as="font" type="font/woff2" crossorigin>
+```
+
+### Variable fonts
+```css
+/* One file instead of multiple weights */
+@font-face {
+  font-family: 'Inter';
+  src: url('/fonts/Inter-Variable.woff2') format('woff2-variations');
+  font-weight: 100 900;
+  font-display: swap;
+}
+```
+
+## Caching strategy
+
+### Cache-Control headers
+```
+# HTML (short or no cache)
+Cache-Control: no-cache, must-revalidate
+
+# Static assets with hash (immutable)
+Cache-Control: public, max-age=31536000, immutable
+
+# Static assets without hash
+Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+# API responses
+Cache-Control: private, max-age=0, must-revalidate
+```
+
+### Service worker caching
+```javascript
+// Cache-first for static assets
+self.addEventListener('fetch', (event) => {
+  if (event.request.destination === 'image' ||
+      event.request.destination === 'style' ||
+      event.request.destination === 'script') {
+    event.respondWith(
+      caches.match(event.request).then((cached) => {
+        return cached || fetch(event.request).then((response) => {
+          const clone = response.clone();
+          caches.open('static-v1').then((cache) => cache.put(event.request, clone));
+          return response;
+        });
+      })
+    );
+  }
+});
+```
+
+## Runtime performance
+
+### Avoid layout thrashing
+```javascript
+// ❌ Forces multiple reflows
+elements.forEach(el => {
+  const height = el.offsetHeight; // Read
+  el.style.height = height + 10 + 'px'; // Write
+});
+
+// ✅ Batch reads, then batch writes
+const heights = elements.map(el => el.offsetHeight); // All reads
+elements.forEach((el, i) => {
+  el.style.height = heights[i] + 10 + 'px'; // All writes
+});
+```
+
+### Debounce expensive operations
+```javascript
+function debounce(fn, delay) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+}
+
+// Debounce scroll/resize handlers
+window.addEventListener('scroll', debounce(handleScroll, 100));
+```
+
+### Use requestAnimationFrame
+```javascript
+// ❌ May cause jank
+setInterval(animate, 16);
+
+// ✅ Synced with display refresh
+function animate() {
+  // Animation logic
+  requestAnimationFrame(animate);
+}
+requestAnimationFrame(animate);
+```
+
+### Virtualize long lists
+```javascript
+// For lists > 100 items, render only visible items
+// Use libraries like react-window, vue-virtual-scroller, or native CSS:
+.virtual-list {
+  content-visibility: auto;
+  contain-intrinsic-size: 0 50px; /* Estimated item height */
+}
+```
+
+## Third-party scripts
+
+### Load strategies
+```javascript
+// ❌ Blocks main thread
+<script src="https://analytics.example.com/script.js"></script>
+
+// ✅ Async loading
+<script async src="https://analytics.example.com/script.js"></script>
+
+// ✅ Delay until interaction
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const observer = new IntersectionObserver((entries) => {
+    if (entries[0].isIntersecting) {
+      const script = document.createElement('script');
+      script.src = 'https://widget.example.com/embed.js';
+      document.body.appendChild(script);
+      observer.disconnect();
+    }
+  });
+  observer.observe(document.querySelector('#widget-container'));
+});
+</script>
+```
+
+### Facade pattern
+```html
+<!-- Show static placeholder until interaction -->
+<div class="youtube-facade" 
+     data-video-id="abc123" 
+     onclick="loadYouTube(this)">
+  <img src="/thumbnails/abc123.jpg" alt="Video title">
+  <button aria-label="Play video">▶</button>
+</div>
+```
+
+## Measurement
+
+### Key metrics
+| Metric | Target | Tool |
+|--------|--------|------|
+| LCP | < 2.5s | Lighthouse, CrUX |
+| FCP | < 1.8s | Lighthouse |
+| Speed Index | < 3.4s | Lighthouse |
+| TBT | < 200ms | Lighthouse |
+| TTI | < 3.8s | Lighthouse |
+
+### Testing commands
+```bash
+# Lighthouse CLI
+npx lighthouse https://example.com --output html --output-path report.html
+
+# Web Vitals library
+import {onLCP, onINP, onCLS} from 'web-vitals';
+onLCP(console.log);
+onINP(console.log);
+onCLS(console.log);
+```
+
+## References
+
+For Core Web Vitals specific optimizations, see [Core Web Vitals](../core-web-vitals/SKILL.md).

--- a/includes/skills/web-quality/performance.md
+++ b/includes/skills/web-quality/performance.md
@@ -358,4 +358,4 @@ onCLS(console.log);
 
 ## References
 
-For Core Web Vitals specific optimizations, see [Core Web Vitals](../core-web-vitals/SKILL.md).
+For Core Web Vitals specific optimizations, see [Core Web Vitals](./core-web-vitals.md).

--- a/includes/skills/web-quality/performance.md
+++ b/includes/skills/web-quality/performance.md
@@ -109,6 +109,7 @@ debounce(fn, 300);
 ## Image optimization
 
 ### Format selection
+
 | Format | Use case | Browser support |
 |--------|----------|-----------------|
 | AVIF | Photos, best compression | 92%+ |
@@ -208,7 +209,8 @@ body {
 ## Caching strategy
 
 ### Cache-Control headers
-```
+
+```http
 # HTML (short or no cache)
 Cache-Control: no-cache, must-revalidate
 
@@ -336,6 +338,7 @@ document.addEventListener('DOMContentLoaded', () => {
 ## Measurement
 
 ### Key metrics
+
 | Metric | Target | Tool |
 |--------|--------|------|
 | LCP | < 2.5s | Lighthouse, CrUX |
@@ -345,12 +348,15 @@ document.addEventListener('DOMContentLoaded', () => {
 | TTI | < 3.8s | Lighthouse |
 
 ### Testing commands
+
 ```bash
 # Lighthouse CLI
 npx lighthouse https://example.com --output html --output-path report.html
+```
 
-# Web Vitals library
-import {onLCP, onINP, onCLS} from 'web-vitals';
+```javascript
+// Web Vitals library
+import { onLCP, onINP, onCLS } from 'web-vitals';
 onLCP(console.log);
 onINP(console.log);
 onCLS(console.log);

--- a/includes/skills/wordpress/wp-performance.md
+++ b/includes/skills/wordpress/wp-performance.md
@@ -1,0 +1,146 @@
+---
+name: wp-performance
+description: "Use when investigating or improving WordPress performance (backend-only agent): profiling and measurement (WP-CLI profile/doctor, Server-Timing, Query Monitor via REST headers), database/query optimization, autoloaded options, object caching, cron, HTTP API calls, and safe verification."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Backend-only agent; prefers WP-CLI (doctor/profile) when available."
+---
+
+# WP Performance (backend-only)
+
+## When to use
+
+Use this skill when:
+
+- a WordPress site/page/endpoint is slow (frontend TTFB, admin, REST, WP-Cron)
+- you need a profiling plan and tooling recommendations (WP-CLI profile/doctor, Query Monitor, Xdebug/XHProf, APMs)
+- you’re optimizing DB queries, autoloaded options, object caching, cron tasks, or remote HTTP calls
+
+This skill assumes the agent cannot use a browser UI. Prefer WP-CLI, logs, and HTTP requests.
+
+## Inputs required
+
+- Environment and safety: dev/staging/prod, any restrictions (no writes, no plugin installs).
+- How to target the install:
+  - WP root `--path=<path>`
+  - (multisite/site targeting) `--url=<url>`
+- The performance symptom and scope:
+  - which URL/REST route/admin screen
+  - when it happens (always vs sporadic; logged-in vs logged-out)
+
+## Procedure
+
+### 0) Guardrails: measure first, avoid risky ops
+
+1. Confirm whether you may run write operations (plugin installs, config changes, cache flush).
+2. Pick a reproducible target (URL or REST route) and capture a baseline:
+   - TTFB/time with `curl` if possible
+   - WP-CLI profiling if available
+
+Read:
+- `references/measurement.md`
+
+### 1) Generate a backend-only performance report (deterministic)
+
+Run:
+
+- `node skills/wp-performance/scripts/perf_inspect.mjs --path=<path> [--url=<url>]`
+
+This detects:
+
+- WP-CLI availability and core version
+- whether `wp doctor` / `wp profile` are available
+- autoloaded options size (if possible)
+- object-cache drop-in presence
+
+### 2) Fast wins: run diagnostics before deep profiling
+
+If you have WP-CLI access, prefer:
+
+- `wp doctor check`
+
+It catches common production foot-guns (autoload bloat, SAVEQUERIES/WP_DEBUG, plugin counts, updates).
+
+Read:
+- `references/wp-cli-doctor.md`
+
+### 3) Deep profiling (no browser required)
+
+Preferred order:
+
+1. `wp profile stage` to see where time goes (bootstrap/main_query/template).
+2. `wp profile hook` (optionally with `--url=`) to find slow hooks/callbacks.
+3. `wp profile eval` for targeted code paths.
+
+Read:
+- `references/wp-cli-profile.md`
+
+### 4) Query Monitor (backend-only usage)
+
+Query Monitor is normally UI-driven, but it can be used headlessly via REST API response headers and `_envelope` responses:
+
+- Authenticate (nonce or Application Password).
+- Request REST responses and inspect headers (`x-qm-*`) and/or the `qm` property when using `?_envelope`.
+
+Read:
+- `references/query-monitor-headless.md`
+
+### 5) Fix by category (choose the dominant bottleneck)
+
+Use the profile output to pick *one* primary bottleneck category:
+
+- **DB queries** → reduce query count, fix N+1 patterns, improve indexes, avoid expensive meta queries.
+  - `references/database.md`
+- **Autoloaded options** → identify the biggest autoloaded options and stop autoloading large blobs.
+  - `references/autoload-options.md`
+- **Object cache misses** → introduce caching or fix cache key/group usage; add persistent object cache where appropriate.
+  - `references/object-cache.md`
+- **Remote HTTP calls** → add timeouts, caching, batching; avoid calling remote APIs on every request.
+  - `references/http-api.md`
+- **Cron** → reduce due-now spikes, de-duplicate events, move heavy tasks out of request paths.
+  - `references/cron.md`
+
+### 6) Verify (repeat the same measurement)
+
+- Re-run the same `wp profile` / `wp doctor` / REST request.
+- Confirm the performance delta and that behavior is unchanged.
+- If the fix is risky, ship behind a feature flag or staged rollout when possible.
+
+## WordPress 6.9 performance improvements
+
+Be aware of these 6.9 changes when profiling:
+
+**On-demand CSS for classic themes:**
+- Classic themes now get on-demand CSS loading (previously only block themes had this).
+- Reduces CSS payload by 30-65% by only loading styles for blocks actually used on the page.
+- If you're profiling a classic theme, this should already be helping.
+
+**Block themes with no render-blocking resources:**
+- Block themes that don't define custom stylesheets (like Twenty Twenty-Three/Four) can now load with zero render-blocking CSS.
+- Styles come from global styles (theme.json) and separate block styles, all inlined.
+- This significantly improves LCP (Largest Contentful Paint).
+
+**Inline CSS limit increased:**
+- The threshold for inlining small stylesheets has been raised, reducing render-blocking resources.
+
+Reference: https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/
+
+## Verification
+
+- Baseline vs after numbers are captured (same environment, same URL/route).
+- `wp doctor check` is clean (or improved) when applicable.
+- No new PHP errors or warnings in logs.
+- No cache flush is required for correctness (cache flush should be last resort).
+
+## Failure modes / debugging
+
+- “No change” after code changes:
+  - you measured a different URL/site (`--url` mismatch), caches masked results, or opcode cache is stale
+- Profiling data is noisy:
+  - eliminate background tasks, test with warmed caches, run multiple samples
+- `SAVEQUERIES`/Query Monitor causes overhead:
+  - don’t run in production unless explicitly approved
+
+## Escalation
+
+- If this is production and you don’t have explicit approval, do not:
+  - install plugins, enable `SAVEQUERIES`, run load tests, or flush caches during traffic
+- If you need system-level profiling (APM, PHP profiler extensions), coordinate with ops/hosting.

--- a/includes/skills/wordpress/wp-plugin-development.md
+++ b/includes/skills/wordpress/wp-plugin-development.md
@@ -1,0 +1,112 @@
+---
+name: wp-plugin-development
+description: "Use when developing WordPress plugins: architecture and hooks, activation/deactivation/uninstall, admin UI and Settings API, data storage, cron/tasks, security (nonces/capabilities/sanitization/escaping), and release packaging."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Filesystem-based agent with bash + node. Some workflows require WP-CLI."
+---
+
+# WP Plugin Development
+
+## When to use
+
+Use this skill for plugin work such as:
+
+- creating or refactoring plugin structure (bootstrap, includes, namespaces/classes)
+- adding hooks/actions/filters
+- activation/deactivation/uninstall behavior and migrations
+- adding settings pages / options / admin UI (Settings API)
+- security fixes (nonces, capabilities, sanitization/escaping, SQL safety)
+- packaging a release (build artifacts, readme, assets)
+
+## Inputs required
+
+- Repo root + target plugin(s) (path to plugin main file if known).
+- Where this plugin runs: single site vs multisite; WP.com conventions if applicable.
+- Target WordPress + PHP versions (affects available APIs and placeholder support in `$wpdb->prepare()`).
+
+## Procedure
+
+### 0) Triage and locate plugin entrypoints
+
+1. Run triage:
+   - `node skills/wp-project-triage/scripts/detect_wp_project.mjs`
+2. Detect plugin headers (deterministic scan):
+   - `node skills/wp-plugin-development/scripts/detect_plugins.mjs`
+
+If this is a full site repo, pick the specific plugin under `wp-content/plugins/` or `mu-plugins/` before changing code.
+
+### 1) Follow a predictable architecture
+
+Guidelines:
+
+- Keep a single bootstrap (main plugin file with header).
+- Avoid heavy side effects at file load time; load on hooks.
+- Prefer a dedicated loader/class to register hooks.
+- Keep admin-only code behind `is_admin()` (or admin hooks) to reduce frontend overhead.
+
+See:
+- `references/structure.md`
+
+### 2) Hooks and lifecycle (activation/deactivation/uninstall)
+
+Activation hooks are fragile; follow guardrails:
+
+- register activation/deactivation hooks at top-level, not inside other hooks
+- flush rewrite rules only when needed and only after registering CPTs/rules
+- uninstall should be explicit and safe (`uninstall.php` or `register_uninstall_hook`)
+
+See:
+- `references/lifecycle.md`
+
+### 3) Settings and admin UI (Settings API)
+
+Prefer Settings API for options:
+
+- `register_setting()`, `add_settings_section()`, `add_settings_field()`
+- sanitize via `sanitize_callback`
+
+See:
+- `references/settings-api.md`
+
+### 4) Security baseline (always)
+
+Before shipping:
+
+- Validate/sanitize input early; escape output late.
+- Use nonces to prevent CSRF *and* capability checks for authorization.
+- Avoid directly trusting `$_POST` / `$_GET`; use `wp_unslash()` and specific keys.
+- Use `$wpdb->prepare()` for SQL; avoid building SQL with string concatenation.
+
+See:
+- `references/security.md`
+
+### 5) Data storage, cron, migrations (if needed)
+
+- Prefer options for small config; custom tables only if necessary.
+- For cron tasks, ensure idempotency and provide manual run paths (WP-CLI or admin).
+- For schema changes, write upgrade routines and store schema version.
+
+See:
+- `references/data-and-cron.md`
+
+## Verification
+
+- Plugin activates with no fatals/notices.
+- Settings save and read correctly (capability + nonce enforced).
+- Uninstall removes intended data (and nothing else).
+- Run repo lint/tests (PHPUnit/PHPCS if present) and any JS build steps if the plugin ships assets.
+
+## Failure modes / debugging
+
+- Activation hook not firing:
+  - hook registered incorrectly (not in main file scope), wrong main file path, or plugin is network-activated
+- Settings not saving:
+  - settings not registered, wrong option group, missing capability, nonce failure
+- Security regressions:
+  - nonce present but missing capability checks; or sanitized input not escaped on output
+
+See:
+- `references/debugging.md`
+
+## Escalation
+
+For canonical detail, consult the Plugin Handbook and security guidelines before inventing patterns.


### PR DESCRIPTION
## Summary

Fixes #57. Grounds the wizard's AI recommendations in well-known web performance and WordPress best practices by bundling verbatim `SKILL.md` playbooks from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills) (MIT) and [WordPress/agent-skills](https://github.com/WordPress/agent-skills) (GPL-2.0-or-later), and injecting the relevant ones as reference context on each analysis step.

### What's in the box

- **`includes/skills/`** — verbatim SKILL.md copies (pinned commits) with attribution in `includes/skills/NOTICE.md`:
  - `web-quality/performance.md`
  - `web-quality/core-web-vitals.md`
  - `web-quality/best-practices.md`
  - `wordpress/wp-performance.md`
  - `wordpress/wp-plugin-development.md`
- **`Performance_Wizard_Skills`** — registers skills, maps each step to relevant slugs, builds a combined reference prompt.
- **Analysis plan** — prepends the reference prompt inside `do_run_action` when skills are enabled.
- **Settings** — new "Include expert skills" toggle (default **on**) on the Performance Wizard → Settings screen.
- **Filters** — `wp_performance_wizard_use_expert_skills` (bool) and `wp_performance_wizard_skill_slugs_for_step` (array).

### Step → skill mapping

| Step                | Skills injected |
|---------------------|--------------------------------------------|
| Lighthouse          | performance, core-web-vitals               |
| HTML                | best-practices, performance                |
| Script Attribution  | performance, best-practices                |
| Themes and Plugins  | wp-performance, wp-plugin-development      |
| Summarize Results   | core-web-vitals, wp-performance (reserved) |

### Tradeoffs

- Each step's prompt grows by ~4–12 KB; the toggle lets cost-sensitive users opt out. Both licenses are compatible with this plugin's GPLv2+.

## Test plan

- [ ] `composer run lint` passes (PHPCS)
- [ ] `composer run phpstan` passes
- [ ] Settings → "Include expert skills" toggle persists across save
- [ ] Running analysis with the toggle **on** shows an extra reference-guidance entry in the conversation UI and produces recommendations that reference known patterns
- [ ] Running analysis with the toggle **off** behaves exactly as before
- [ ] `wp_performance_wizard_skill_slugs_for_step` filter can add/remove/override skills per step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analysis steps can include bundled expert reference guidance drawn from curated skill playbooks; settings let you enable/disable this behavior (on by default).

* **Documentation**
  * Added comprehensive expert playbooks for performance, Core Web Vitals, WordPress tuning, and plugin development, plus a NOTICE documenting upstream sources, attributions, and licensing for bundled skill content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->