### PR TITLE
Add a "Start New Conversation" button

### DIFF
--- a/includes/class-performance-wizard-admin-page.php
+++ b/includes/class-performance-wizard-admin-page.php
@@ -100,8 +100,11 @@ class Performance_Wizard_Admin_Page {
 			echo '<input type="hidden" class="performance-wizard-data-source" value="' . esc_attr( $step ) . '" checked>';
 		}
 
-		// Add a start button.
-		echo '<p><button id="performance-wizard-start" class="button button-primary">' . esc_html__( 'Start analysis', 'wp-performance-wizard' ) . '</button></p>';
+		// Add a start button and a button to reset and start a new conversation.
+		echo '<p>';
+		echo '<button id="performance-wizard-start" class="button button-primary">' . esc_html__( 'Start analysis', 'wp-performance-wizard' ) . '</button> ';
+		echo '<button id="performance-wizard-new-conversation" class="button button-secondary">' . esc_html__( 'Start New Conversation', 'wp-performance-wizard' ) . '</button>';
+		echo '</p>';
 
 		// Close main content div.
 		echo '</div>';
@@ -212,7 +215,8 @@ class Performance_Wizard_Admin_Page {
 			'wp-performance-wizard',
 			'wpPerformanceWizard',
 			array(
-				'nonce' => wp_create_nonce( 'save_model_preference' ),
+				'nonce'      => wp_create_nonce( 'save_model_preference' ),
+				'resetNonce' => wp_create_nonce( 'reset_conversation' ),
 			)
 		);
 	}

--- a/includes/class-performance-wizard-rest-api.php
+++ b/includes/class-performance-wizard-rest-api.php
@@ -60,6 +60,19 @@ class Performance_Wizard_Rest_API {
 						},
 					)
 				);
+
+				// Register the reset conversation route.
+				register_rest_route(
+					'performance-wizard/v1',
+					'/reset-conversation/',
+					array(
+						'methods'             => array( 'POST' ),
+						'callback'            => array( $this, 'reset_conversation' ),
+						'permission_callback' => static function () {
+							return current_user_can( 'manage_options' );
+						},
+					)
+				);
 			}
 		);
 	}
@@ -172,5 +185,37 @@ class Performance_Wizard_Rest_API {
 				500
 			);
 		}
+	}
+
+	/**
+	 * Reset the current conversation.
+	 *
+	 * Deletes the stored analysis plan steps option so a fresh analysis
+	 * starts with a clean slate.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response The response object.
+	 */
+	public function reset_conversation( WP_REST_Request $request ): WP_REST_Response {
+		// Verify nonce for security.
+		$nonce = $request->get_param( 'nonce' );
+		if ( ! wp_verify_nonce( $nonce, 'reset_conversation' ) ) {
+			return new WP_REST_Response(
+				array( 'error' => 'Invalid nonce' ),
+				403
+			);
+		}
+
+		// Delete the stored conversation so the next analysis starts clean.
+		delete_option( $this->wizard->get_option_name() );
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'message' => 'Conversation reset successfully',
+			),
+			200
+		);
 	}
 }

--- a/includes/js/wp-performance-wizard.js
+++ b/includes/js/wp-performance-wizard.js
@@ -53,6 +53,58 @@
 		runAnalysis( checkedDataSources );
 	} );
 
+	// Wait until the performance-wizard-new-conversation button has been
+	// clicked, then reset the stored conversation and clear the terminal.
+	const newConversationButton = document.getElementById( 'performance-wizard-new-conversation' );
+	if ( newConversationButton ) {
+		newConversationButton.addEventListener( 'click', function() {
+			resetConversation();
+		} );
+	}
+
+	/**
+	 * Reset the conversation by clearing the stored prompts/responses on the
+	 * server, then clearing the terminal and re-enabling the start button so
+	 * a fresh analysis can be run.
+	 */
+	function resetConversation() {
+		if ( ! wpPerformanceWizard || ! wpPerformanceWizard.resetNonce ) {
+			console.error( 'Missing nonce for resetting conversation' );
+			return;
+		}
+
+		const params = {
+			'nonce': wpPerformanceWizard.resetNonce
+		};
+
+		wp.apiFetch( {
+			path  : '/performance-wizard/v1/reset-conversation/',
+			method: 'POST',
+			data  : params
+		} ).then( function( response ) {
+			if ( response.success ) {
+				// Clear the terminal output.
+				terminal.innerHTML = '';
+
+				// Remove any lingering follow-up question input.
+				const followUp = document.getElementById( 'wp-performance-wizard-follow-up' );
+				if ( followUp ) {
+					followUp.remove();
+				}
+
+				// Re-enable the start button so a fresh analysis can be run.
+				const startButton = document.getElementById( 'performance-wizard-start' );
+				if ( startButton ) {
+					startButton.disabled = false;
+				}
+			} else {
+				console.error( 'Failed to reset conversation:', response.error );
+			}
+		} ).catch( function( error ) {
+			console.error( 'Error resetting conversation:', error );
+		} );
+	}
+
 	/**
 	 * Get the selected AI model from the form.
 	 */


### PR DESCRIPTION
## Summary

Implements #14 by adding a way for users to reset the wizard and start a fresh conversation without leftover prompts/responses from a prior run.

### New REST endpoint

`POST /performance-wizard/v1/reset-conversation/`

- `permission_callback` requires `current_user_can( 'manage_options' )`.
- Nonce-verified using a dedicated `reset_conversation` nonce action, following the existing `save-model-preference` pattern.
- Handler deletes the wizard conversation option (`WP_Performance_Wizard::get_option_name()`) so the next analysis starts with a clean slate, and returns a success JSON response.

### Button

- New "Start New Conversation" button (`#performance-wizard-new-conversation`, `button button-secondary`) rendered next to the existing start button in `render_page()`. Label localized with `esc_html__`.
- A dedicated `resetNonce` is localized alongside the existing `nonce` key in the `wpPerformanceWizard` object (the existing `nonce` key is untouched).

### JS reset behavior

On click, the handler calls the reset endpoint with the nonce and, on success:

- Clears the terminal DOM (`#performance-wizard-terminal` innerHTML).
- Removes any lingering follow-up question input (`#wp-performance-wizard-follow-up`).
- Re-enables the `#performance-wizard-start` button (which gets `disabled = true` on first run), so a fresh analysis can be started.

Code style matches the existing file (vanilla JS, `wp.apiFetch`).

### Out of scope (possible follow-up)

The issue notes that storing prior conversations for later access is optional ("could maybe"). Conversation-history archival was deliberately left out of this PR to keep scope tight and can be addressed as a separate follow-up.

### Verification

- `composer run lint` — passes.
- `composer run phpstan` — passes.

Closes #14.