### PR TITLE
Persist analysis history as revisitable sessions

### DIFF
--- a/includes/class-performance-wizard-admin-page.php
+++ b/includes/class-performance-wizard-admin-page.php
@@ -126,6 +126,10 @@ class Performance_Wizard_Admin_Page {
 
 		// Close container wrapper.
 		echo '</div>';
+
+		// Add the analysis history panel, populated client-side via REST.
+		echo '<h3>' . esc_html__( 'Analysis History', 'wp-performance-wizard' ) . '</h3>';
+		echo '<div id="performance-wizard-history"></div>';
 	}
 
 	/**

--- a/includes/class-performance-wizard-history.php
+++ b/includes/class-performance-wizard-history.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * A class to persist completed analysis runs as revisitable sessions.
+ *
+ * @package wp-performance-wizard
+ */
+
+/**
+ * Stores completed analysis runs in a single capped option so users can
+ * revisit a past run's transcript read-only from the admin page.
+ */
+class Performance_Wizard_History {
+
+	/**
+	 * The name of the option used to store the analysis history.
+	 *
+	 * @var string
+	 */
+	const OPTION_NAME = 'performance_wizard_analysis_history';
+
+	/**
+	 * Maximum number of sessions retained. The oldest is evicted once exceeded.
+	 *
+	 * @var int
+	 */
+	const MAX_SESSIONS = 20;
+
+	/**
+	 * The transcript entry types that may be archived.
+	 *
+	 * @var string[]
+	 */
+	const ALLOWED_TYPES = array( 'step', 'recommendations', 'qa' );
+
+	/**
+	 * Archive a completed analysis run as a non-destructive snapshot.
+	 *
+	 * The transcript is captured client-side because the final recommendations
+	 * and follow-up Q&A are not persisted server-side. The plan steps option is
+	 * intentionally left untouched so post-completion follow-up questions keep
+	 * working.
+	 *
+	 * @param string           $model        The AI model used for the run.
+	 * @param array<int,mixed> $data_sources The data source names selected for the run.
+	 * @param array<int,mixed> $transcript   The captured transcript entries.
+	 *
+	 * @return array<string,mixed> The saved record, or an empty array when nothing was archived.
+	 */
+	public function archive( string $model, array $data_sources, array $transcript ): array {
+		$clean_transcript = $this->sanitize_transcript( $transcript );
+
+		// Nothing meaningful to store.
+		if ( array() === $clean_transcript ) {
+			return array();
+		}
+
+		$clean_model = sanitize_text_field( $model );
+
+		$clean_sources = array();
+		foreach ( $data_sources as $data_source ) {
+			$clean_sources[] = sanitize_text_field( (string) $data_source );
+		}
+
+		$history = $this->get_history();
+
+		// Dedupe: skip when the newest existing record has an identical transcript.
+		if ( array() !== $history ) {
+			$newest = $history[0];
+			if ( isset( $newest['transcript'] ) && $newest['transcript'] === $clean_transcript ) {
+				return $newest;
+			}
+		}
+
+		$record = array(
+			'id'           => uniqid( 'pw_', true ),
+			'created'      => current_time( 'mysql' ),
+			'timestamp'    => time(),
+			'model'        => $clean_model,
+			'data_sources' => $clean_sources,
+			'transcript'   => $clean_transcript,
+		);
+
+		// Newest first, capped to MAX_SESSIONS (evict oldest).
+		array_unshift( $history, $record );
+		if ( count( $history ) > self::MAX_SESSIONS ) {
+			$history = array_slice( $history, 0, self::MAX_SESSIONS );
+		}
+
+		update_option( self::OPTION_NAME, $history, false );
+
+		return $record;
+	}
+
+	/**
+	 * Get a lightweight listing of stored sessions.
+	 *
+	 * The transcript itself is omitted for an efficient listing; an entry count
+	 * is included instead.
+	 *
+	 * @return array<int,array<string,mixed>> The sessions, newest first, without transcripts.
+	 */
+	public function get_sessions(): array {
+		$sessions = array();
+
+		foreach ( $this->get_history() as $record ) {
+			$transcript = isset( $record['transcript'] ) && is_array( $record['transcript'] ) ? $record['transcript'] : array();
+
+			$sessions[] = array(
+				'id'           => isset( $record['id'] ) ? (string) $record['id'] : '',
+				'created'      => isset( $record['created'] ) ? (string) $record['created'] : '',
+				'timestamp'    => isset( $record['timestamp'] ) ? (int) $record['timestamp'] : 0,
+				'model'        => isset( $record['model'] ) ? (string) $record['model'] : '',
+				'data_sources' => isset( $record['data_sources'] ) && is_array( $record['data_sources'] ) ? $record['data_sources'] : array(),
+				'entry_count'  => count( $transcript ),
+			);
+		}
+
+		return $sessions;
+	}
+
+	/**
+	 * Get the full stored record for a single session.
+	 *
+	 * @param string $id The session id.
+	 *
+	 * @return array<string,mixed>|null The full record, or null when not found.
+	 */
+	public function get_session( string $id ): ?array {
+		foreach ( $this->get_history() as $record ) {
+			if ( isset( $record['id'] ) && (string) $record['id'] === $id ) {
+				return $record;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the raw stored history list.
+	 *
+	 * @return array<int,array<string,mixed>> The stored records, newest first.
+	 */
+	private function get_history(): array {
+		$history = get_option( self::OPTION_NAME, array() );
+
+		if ( ! is_array( $history ) ) {
+			return array();
+		}
+
+		return $history;
+	}
+
+	/**
+	 * Validate and sanitize a client-supplied transcript.
+	 *
+	 * Each entry's type is whitelisted and its title is sanitized. The content
+	 * is kept as a plain string (cast only) because it is Markdown that the
+	 * client re-renders through marked(); it is intentionally not passed
+	 * through wp_kses.
+	 *
+	 * @param array<int,mixed> $transcript The raw transcript entries.
+	 *
+	 * @return array<int,array<string,string>> The sanitized transcript entries.
+	 */
+	private function sanitize_transcript( array $transcript ): array {
+		$clean = array();
+
+		foreach ( $transcript as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$type = isset( $entry['type'] ) ? (string) $entry['type'] : '';
+			if ( ! in_array( $type, self::ALLOWED_TYPES, true ) ) {
+				continue;
+			}
+
+			$title   = isset( $entry['title'] ) ? sanitize_text_field( (string) $entry['title'] ) : '';
+			$content = isset( $entry['content'] ) ? (string) $entry['content'] : '';
+
+			$clean[] = array(
+				'type'    => $type,
+				'title'   => $title,
+				'content' => $content,
+			);
+		}
+
+		return $clean;
+	}
+}

--- a/includes/class-performance-wizard-rest-api.php
+++ b/includes/class-performance-wizard-rest-api.php
@@ -126,6 +126,34 @@ class Performance_Wizard_Rest_API {
 				} else {
 					$response = $this->wizard->get_ai_agent()->send_prompt( $prompt, $step, $previous_steps, $additional_questions );
 				}
+				break;
+			case '_archive_session_':
+				$data_sources = $request->get_param( 'data_sources' );
+				$transcript   = $request->get_param( 'transcript' );
+
+				$data_sources = is_array( $data_sources ) ? $data_sources : array();
+				$transcript   = is_array( $transcript ) ? $transcript : array();
+				$model        = is_string( $model ) ? $model : '';
+
+				$response = $this->wizard->get_history()->archive( $model, $data_sources, $transcript );
+				break;
+			case '_get_sessions_':
+				$response = $this->wizard->get_history()->get_sessions();
+				break;
+			case '_get_session_':
+				$session_id = $request->get_param( 'session_id' );
+				$session_id = is_string( $session_id ) ? sanitize_text_field( $session_id ) : '';
+				$session    = $this->wizard->get_history()->get_session( $session_id );
+
+				if ( null === $session ) {
+					return new WP_REST_Response(
+						array( 'error' => 'Session not found.' ),
+						404
+					);
+				}
+
+				$response = $session;
+				break;
 		}
 
 		return new WP_REST_Response( $response, 200 );

--- a/includes/class-wp-performance-wizard.php
+++ b/includes/class-wp-performance-wizard.php
@@ -54,6 +54,13 @@ class WP_Performance_Wizard {
 	private $analysis_plan;
 
 	/**
+	 * The analysis history store.
+	 *
+	 * @var Performance_Wizard_History
+	 */
+	private $history;
+
+	/**
 	 * The AI Agent.
 	 *
 	 * @var Performance_Wizard_AI_Agent_Base|null
@@ -146,6 +153,9 @@ class WP_Performance_Wizard {
 		// Load the Analysis plan.
 		$this->analysis_plan = new Performance_Wizard_Analysis_Plan( $this );
 
+		// Load the analysis history store.
+		$this->history = new Performance_Wizard_History();
+
 		// Load the $supported_agents, eg. call new Performance_Wizard_AI_Agent_Gemini( $this ) for each agent.
 		foreach ( $this->supported_agents as $agent_name => $agent_class_name ) {
 			$agent = new $agent_class_name( $this );
@@ -179,6 +189,7 @@ class WP_Performance_Wizard {
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-settings-page.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-skills.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-analysis-plan.php';
+		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-history.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-rest-api.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-ai-agent-base.php';
 		require_once plugin_dir_path( __FILE__ ) . 'class-performance-wizard-ai-agent-gemini.php';
@@ -194,6 +205,15 @@ class WP_Performance_Wizard {
 	 */
 	public function get_analysis_plan(): Performance_Wizard_Analysis_Plan {
 		return $this->analysis_plan;
+	}
+
+	/**
+	 * Get the analysis history store.
+	 *
+	 * @return Performance_Wizard_History The analysis history store.
+	 */
+	public function get_history(): Performance_Wizard_History {
+		return $this->history;
 	}
 
 	/**

--- a/includes/js/wp-performance-wizard.js
+++ b/includes/js/wp-performance-wizard.js
@@ -4,6 +4,26 @@
 	// The performance-wizard-terminal div will be used to display all communications with the agent.
 	const terminal = document.getElementById( 'performance-wizard-terminal' );
 
+	// Module-scoped transcript of the current run. Each entry is
+	// { type: 'step'|'recommendations'|'qa', title, content } where content is
+	// the raw Markdown string (not HTML) so it can be re-rendered later.
+	let currentTranscript = [];
+
+	/**
+	 * Record a transcript entry for the current run.
+	 *
+	 * @param {string} type    One of 'step', 'recommendations', 'qa'.
+	 * @param {string} title   A short heading for the entry.
+	 * @param {string} content The raw Markdown content.
+	 */
+	function recordTranscript( type, title, content ) {
+		currentTranscript.push( {
+			type   : type,
+			title  : String( title || '' ),
+			content: String( content || '' )
+		} );
+	}
+
 	// Handle layout toggle
 	document.addEventListener( 'click', function( event ) {
 		if ( event.target.classList.contains( 'layout-btn' ) ) {
@@ -48,6 +68,9 @@
 		// another terminal click listener inside runAnalysis) on top of the
 		// first.
 		event.target.disabled = true;
+
+		// Start a fresh transcript for this run.
+		currentTranscript = [];
 
 		// Run the analysis....
 		runAnalysis( checkedDataSources );
@@ -104,6 +127,9 @@
 			console.error( 'Error resetting conversation:', error );
 		} );
 	}
+
+	// Load the history panel on page load.
+	loadHistory();
 
 	/**
 	 * Get the selected AI model from the form.
@@ -204,6 +230,9 @@
 				terminal.appendChild( responseDiv );
 				await streamText( responseDiv, results || '', 25 );
 
+				// Record the follow-up question and answer as raw Markdown.
+				recordTranscript( 'qa', 'Q: ' + question, 'Q: ' + question + '\n\nA: ' + ( results || '' ) );
+
 				addFollowUpQuestion();
 			}
 		} );
@@ -247,6 +276,12 @@
 			const promptForDisplay = nextStep.display_prompt ? nextStep.display_prompt : nextStep.user_prompt;
 			switch ( nextStep.action ) {
 				case 'complete':
+					// Archive the completed run as a non-destructive snapshot.
+					// The transcript is captured client-side because the final
+					// recommendations and follow-up Q&A are not persisted
+					// server-side.
+					archiveSession( selectedModel, dataSources, currentTranscript );
+
 					// Output the input field so users can ask follow up questions.
 					addFollowUpQuestion();
 
@@ -278,11 +313,16 @@
 
 					echoToTerminal( '### <div class="dc">Analysis...</div>' );
 					// Iterate thru all of the results returned in the response
+					const stepResults = [];
 					for( const resultIndex in results ) {
 						const result = results[ resultIndex ];
+						stepResults.push( String( result || '' ) );
 						echoToTerminal();
 						await outputFormattedResults( result );
 					};
+
+					// Record the concatenated raw Markdown for this data-source step.
+					recordTranscript( 'step', nextStep.title, stepResults.join( '\n\n' ) );
 
 					step++;
 					break;
@@ -302,6 +342,9 @@
 					}
 
 					echoToTerminal( '<br><div class="info-chip agent-chip" aria-label="Agent">AGENT</div><br>' );
+
+					// Record the final recommendations response as raw Markdown.
+					recordTranscript( 'recommendations', nextStep.title || 'Recommendations', result || '' );
 
 					// Use streaming effect for longer AI responses. Both
 					// branches go through the Markdown renderer so formatting
@@ -489,6 +532,158 @@
 			path  : '/performance-wizard/v1/command/',
 			method: 'POST',
 			data  : params
+		} );
+	}
+
+	/**
+	 * Archive the completed run, then refresh the history panel.
+	 *
+	 * @param {string} model       The selected AI model.
+	 * @param {Array}  dataSources  The data source names used for the run.
+	 * @param {Array}  transcript   The captured transcript entries.
+	 */
+	function archiveSession( model, dataSources, transcript ) {
+		if ( ! transcript || transcript.length === 0 ) {
+			return;
+		}
+		wp.apiFetch( {
+			path  : '/performance-wizard/v1/command/',
+			method: 'POST',
+			data  : {
+				'command'     : '_archive_session_',
+				'model'       : model,
+				'data_sources': dataSources,
+				'transcript'  : transcript
+			}
+		} ).then( function() {
+			loadHistory();
+		} ).catch( function( error ) {
+			console.error( 'Error archiving analysis session:', error );
+		} );
+	}
+
+	/**
+	 * Load the list of stored sessions and render the history panel.
+	 */
+	function loadHistory() {
+		const container = document.getElementById( 'performance-wizard-history' );
+		if ( ! container ) {
+			return;
+		}
+		wp.apiFetch( {
+			path  : '/performance-wizard/v1/command/',
+			method: 'POST',
+			data  : { 'command': '_get_sessions_' }
+		} ).then( function( sessions ) {
+			renderHistoryList( container, sessions || [] );
+		} ).catch( function( error ) {
+			console.error( 'Error loading analysis history:', error );
+		} );
+	}
+
+	/**
+	 * Render the history list into the given container.
+	 *
+	 * @param {HTMLElement} container The container element.
+	 * @param {Array}       sessions  The list of session summaries.
+	 */
+	function renderHistoryList( container, sessions ) {
+		container.innerHTML = '';
+
+		if ( ! sessions.length ) {
+			const empty = document.createElement( 'p' );
+			empty.textContent = 'No past analyses yet.';
+			container.appendChild( empty );
+			return;
+		}
+
+		const list = document.createElement( 'ul' );
+		list.className = 'performance-wizard-history-list';
+
+		sessions.forEach( function( session ) {
+			const item = document.createElement( 'li' );
+
+			const label = document.createElement( 'span' );
+			const sourceCount = Array.isArray( session.data_sources ) ? session.data_sources.length : 0;
+			label.textContent = session.created + ' — ' + ( session.model || 'Unknown model' ) +
+				' — ' + sourceCount + ' data source(s)';
+
+			const view = document.createElement( 'button' );
+			view.type = 'button';
+			view.className = 'button performance-wizard-history-view';
+			view.textContent = 'View';
+			view.setAttribute( 'data-session-id', session.id );
+
+			item.appendChild( label );
+			item.appendChild( document.createTextNode( ' ' ) );
+			item.appendChild( view );
+			list.appendChild( item );
+		} );
+
+		container.appendChild( list );
+	}
+
+	// Delegated handler for "View" buttons in the history panel.
+	document.addEventListener( 'click', function( event ) {
+		if ( ! event.target.classList.contains( 'performance-wizard-history-view' ) ) {
+			return;
+		}
+		const sessionId = event.target.getAttribute( 'data-session-id' );
+		if ( ! sessionId ) {
+			return;
+		}
+		wp.apiFetch( {
+			path  : '/performance-wizard/v1/command/',
+			method: 'POST',
+			data  : {
+				'command'   : '_get_session_',
+				'session_id': sessionId
+			}
+		} ).then( function( session ) {
+			if ( ! session || session.error ) {
+				console.error( 'Error loading session:', session && session.error );
+				return;
+			}
+			renderStoredTranscript( session );
+		} ).catch( function( error ) {
+			console.error( 'Error loading session:', error );
+		} );
+	} );
+
+	/**
+	 * Render a stored session transcript read-only into the terminal.
+	 *
+	 * Stored content is Markdown and is rendered through the same marked()
+	 * renderer used by the live terminal (same trust model). Raw HTML is never
+	 * persisted or re-injected.
+	 *
+	 * @param {Object} session The full stored session record.
+	 */
+	function renderStoredTranscript( session ) {
+		if ( ! terminal ) {
+			return;
+		}
+		// Clear the terminal for the read-only view.
+		terminal.innerHTML = '';
+
+		const header = document.createElement( 'div' );
+		header.innerHTML = marked.marked(
+			'## Viewing past analysis (' + ( session.created || '' ) + ')\n\n' +
+			'_Model: ' + ( session.model || 'Unknown' ) + ' — read-only_'
+		);
+		terminal.appendChild( header );
+
+		const transcript = Array.isArray( session.transcript ) ? session.transcript : [];
+		transcript.forEach( function( entry ) {
+			if ( entry.title ) {
+				const heading = document.createElement( 'div' );
+				heading.innerHTML = marked.marked( '### ' + String( entry.title ) );
+				terminal.appendChild( heading );
+			}
+			const body = document.createElement( 'div' );
+			body.className = 'dc';
+			body.innerHTML = marked.marked( String( entry.content || '' ) );
+			terminal.appendChild( body );
 		} );
 	}
 } )();


### PR DESCRIPTION
Implements #62 — store each completed analysis run as a named, timestamped session, add a History panel listing past sessions, and render a selected session's transcript read-only.

## History store (`Performance_Wizard_History`)
New class persists runs in a single option `performance_wizard_analysis_history`: a list of records, **newest first, capped to 20** (oldest evicted on overflow). Each record holds `id`, `created` (mysql) + unix `timestamp`, `model`, `data_sources`, and a `transcript` array of `{ type, title, content }` entries where `content` is Markdown. Inputs are sanitized (`sanitize_text_field` on model/titles/data sources; transcript `type` is whitelisted). **Dedupe**: if the newest existing record has an identical transcript, no duplicate is added. Empty transcripts are not archived.

## Archive-on-complete snapshot (non-destructive)
On the JS `case 'complete':` branch the client POSTs `_archive_session_` with the model, selected data sources, and the captured transcript, then refreshes the panel. Archiving is a **non-destructive snapshot**: it deliberately does **not** delete or clear the `performance_wizard_analysis_plan_steps` option, because post-completion follow-up questions rely on it via `get_option()`.

## Client-side transcript capture
The final recommendations (`_prompt_` / "Summarize Results" step) and follow-up Q&A are **not** persisted server-side (only data-source steps are, via `store_prompts_and_response`). So the client maintains a module-scoped `currentTranscript` and a `recordTranscript()` helper that captures the **raw Markdown string** (never `innerHTML`) at each meaningful point: each data-source step's collected analysis, the final recommendations response, and each follow-up Q&A. Live rendering is unchanged. Stored Markdown is re-rendered through the existing `marked.marked()` renderer — the same trust model as the live terminal.

## History panel + read-only view
The admin page renders an "Analysis History" heading and a `#performance-wizard-history` placeholder populated via REST (`_get_sessions_`, transcript-free listing with an entry count). Each item shows the created date, model, and data-source count plus a "View" button. A delegated handler fetches the full session (`_get_session_`, 404-style `{error}` when missing), clears the terminal, and renders each transcript entry's heading and Markdown content read-only.

## Out of scope (intentionally not built)
Session diffing, cross-site/remote storage, and a separate "delete session" UI.

## Verification
- `composer run lint` (phpcs): `.................. 18 / 18 (100%)` — no violations.
- `composer run phpstan`: `[OK] No errors`.

Closes #62.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Analysis History" section to the Performance Wizard admin page
  * Analysis runs are now automatically saved for future reference
  * Users can view and review previous analysis sessions with their complete transcripts and recommendations
  * Stores up to 20 most recent analyses

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamsilverstein/wp-performance-wizard/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->