### PR TITLE
Analyze multiple page types (Lighthouse + HTML)

### DIFF
--- a/includes/class-performance-wizard-data-source-html.php
+++ b/includes/class-performance-wizard-data-source-html.php
@@ -16,44 +16,46 @@ class Performance_Wizard_Data_Source_HTML extends Performance_Wizard_Data_Source
 	public function __construct() {
 		parent::__construct();
 		$this->set_name( 'HTML' );
-		$this->set_prompt( 'Collecting HTML source for the site, attempting to grab the home page, a recent post and an archive page.' );
-		$this->set_description( 'The HTML data source provides the raw, server-rendered HTML of three representative front-end pages of the site, as retrieved over HTTP by an unauthenticated visitor: the home page, the most recently published post, and the post-type archive page. This is the markup before any client-side JavaScript runs.' );
-		$this->set_data_shape( 'The data is a JSON object with exactly three string keys: "home_page", "most_recent_post" and "archive_page". Each value is the full HTML document returned for that page. Any of these strings may be empty if the page could not be retrieved.' );
-		$this->set_analysis_strategy( 'Inspect the markup of each page for common front-end performance problems: render-blocking scripts and stylesheets in the <head>, missing async/defer on scripts, large or unoptimized inline scripts and styles, missing image dimensions, lack of lazy-loading on below-the-fold images, missing preconnect/preload hints, and excessive third-party embeds. Identify the origin of each asset: files under /wp-content/plugins/<plugin-slug>/ or /wp-content/themes/<theme-slug>/ belong to that plugin or theme, while assets on other domains are third-party scripts and should each be assessed individually for their performance cost. Prioritize issues that correspond to failing audits from the earlier Lighthouse step, and reference the specific tag or asset URL from the HTML when describing a problem. Only report issues you can actually see in the provided markup.' );
+		$this->set_prompt( 'Collecting HTML source for the site for each selected page type (home, archive, and/or most recent post).' );
+		$this->set_description( 'The HTML data source provides the raw, server-rendered HTML of one or more representative front-end page types of the site, as retrieved over HTTP by an unauthenticated visitor. Which page types are included is configurable in the plugin settings (home page, posts archive, and/or most recently published post). This is the markup before any client-side JavaScript runs.' );
+		$this->set_data_shape( 'The data is a JSON object whose keys are the selected page types from the set "home", "archive", and "post" (only the selected types are present). Each value is an object with three string fields: "url" (the URL fetched), "label" (a short human-readable name for the page type), and "html" (the full HTML document returned for that URL, or an empty string when the page could not be retrieved or no URL could be resolved).' );
+		$this->set_analysis_strategy( 'Inspect the markup of each included page type for common front-end performance problems: render-blocking scripts and stylesheets in the <head>, missing async/defer on scripts, large or unoptimized inline scripts and styles, missing image dimensions, lack of lazy-loading on below-the-fold images, missing preconnect/preload hints, and excessive third-party embeds. Identify the origin of each asset: files under /wp-content/plugins/<plugin-slug>/ or /wp-content/themes/<theme-slug>/ belong to that plugin or theme, while assets on other domains are third-party scripts and should each be assessed individually for their performance cost. When more than one page type is included, compare across them and call out template-specific issues - for example a problem present on the post template but absent from the home template. Prioritize issues that correspond to failing audits from the earlier Lighthouse step, and reference the specific tag or asset URL from the HTML when describing a problem. Only report issues you can actually see in the provided markup.' );
 	}
 
 	/**
-	 * Get the HTML of three pages and return in a structured data object
+	 * Get the HTML of each selected page type and return in a structured data object.
 	 *
-	 * The home page, the most recent published post and an archive page should be analyzed.
+	 * The set of page types is configurable via the plugin's Settings page and
+	 * the `wp_performance_wizard_page_types` filter.
 	 *
 	 * @return string JSON encoded string of the HTML data.
 	 */
 	public function get_data(): string {
-		/**
-		 * Filter the site URL used for performance wizard analysis
-		 *
-		 * @param string $site_url The site URL.
-		 * @return string The filtered site URL.
-		 */
-		$site_url       = apply_filters( 'wp_performance_wizard_site_url', get_site_url() );
-		$home_page      = wp_remote_get( $site_url );
-		$home_page_body = wp_remote_retrieve_body( $home_page );
+		$page_types = Performance_Wizard_Settings_Page::page_types();
+		$to_return  = array();
 
-		// Get the most recent post.
-		$posts                 = get_posts( array( 'numberposts' => 1 ) );
-		$most_recent_post      = wp_remote_get( get_permalink( $posts[0]->ID ) );
-		$most_recent_post_body = wp_remote_retrieve_body( $most_recent_post );
+		foreach ( $page_types as $page_type ) {
+			$url   = Performance_Wizard_Settings_Page::get_page_type_url( $page_type );
+			$label = isset( Performance_Wizard_Settings_Page::SUPPORTED_PAGE_TYPES[ $page_type ] )
+				? Performance_Wizard_Settings_Page::SUPPORTED_PAGE_TYPES[ $page_type ]
+				: $page_type;
+			$body  = '';
 
-		$archive_page      = wp_remote_get( get_post_type_archive_link( 'post' ) );
-		$archive_page_body = wp_remote_retrieve_body( $archive_page );
+			if ( '' !== $url ) {
+				$response = wp_remote_get( $url, array( 'timeout' => 30 ) );
+				if ( ! is_wp_error( $response ) ) {
+					$body = wp_remote_retrieve_body( $response );
+				}
+			}
 
-		$to_return = array(
-			'home_page'        => $home_page_body,
-			'most_recent_post' => $most_recent_post_body,
-			'archive_page'     => $archive_page_body,
-		);
+			$to_return[ $page_type ] = array(
+				'url'   => $url,
+				'label' => $label,
+				'html'  => $body,
+			);
+		}
 
-		return wp_json_encode( $to_return );
+		$encoded = wp_json_encode( $to_return );
+		return false === $encoded ? '{}' : $encoded;
 	}
 }

--- a/includes/class-performance-wizard-data-source-html.php
+++ b/includes/class-performance-wizard-data-source-html.php
@@ -33,6 +33,7 @@ class Performance_Wizard_Data_Source_HTML extends Performance_Wizard_Data_Source
 	public function get_data(): string {
 		$page_types = Performance_Wizard_Settings_Page::page_types();
 		$to_return  = array();
+		$cache      = array();
 
 		foreach ( $page_types as $page_type ) {
 			$url   = Performance_Wizard_Settings_Page::get_page_type_url( $page_type );
@@ -42,9 +43,14 @@ class Performance_Wizard_Data_Source_HTML extends Performance_Wizard_Data_Source
 			$body  = '';
 
 			if ( '' !== $url ) {
-				$response = wp_remote_get( $url, array( 'timeout' => 30 ) );
-				if ( ! is_wp_error( $response ) ) {
-					$body = wp_remote_retrieve_body( $response );
+				if ( array_key_exists( $url, $cache ) ) {
+					$body = $cache[ $url ];
+				} else {
+					$response = wp_remote_get( $url, array( 'timeout' => 30 ) );
+					if ( ! is_wp_error( $response ) ) {
+						$body = wp_remote_retrieve_body( $response );
+					}
+					$cache[ $url ] = $body;
 				}
 			}
 

--- a/includes/class-performance-wizard-data-source-lighthouse.php
+++ b/includes/class-performance-wizard-data-source-lighthouse.php
@@ -28,8 +28,17 @@ class Performance_Wizard_Data_Source_Lighthouse extends Performance_Wizard_Data_
 		 * @return string JSON encoded string of the multi-page Lighthouse data.
 		 */
 	public function get_data(): string {
+		// Each PSI call can take up to 3 minutes, so when several page types
+		// are configured the total runtime can easily exceed PHP's default
+		// max execution time. set_time_limit() silently returns false when
+		// disabled by the host, which is the desired no-op behaviour there.
+		if ( function_exists( 'set_time_limit' ) ) {
+			@set_time_limit( 0 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		}
+
 		$page_types = Performance_Wizard_Settings_Page::page_types();
 		$collected  = array();
+		$cache      = array();
 
 		foreach ( $page_types as $page_type ) {
 			$url   = Performance_Wizard_Settings_Page::get_page_type_url( $page_type );
@@ -37,12 +46,19 @@ class Performance_Wizard_Data_Source_Lighthouse extends Performance_Wizard_Data_
 				? Performance_Wizard_Settings_Page::SUPPORTED_PAGE_TYPES[ $page_type ]
 				: $page_type;
 
+			if ( '' === $url ) {
+				$result = array( 'error' => 'No URL could be resolved for this page type.' );
+			} elseif ( array_key_exists( $url, $cache ) ) {
+				$result = $cache[ $url ];
+			} else {
+				$result        = $this->fetch_lighthouse_for_url( $url );
+				$cache[ $url ] = $result;
+			}
+
 			$collected[ $page_type ] = array(
 				'url'    => $url,
 				'label'  => $label,
-				'result' => '' === $url
-					? array( 'error' => 'No URL could be resolved for this page type.' )
-					: $this->fetch_lighthouse_for_url( $url ),
+				'result' => $result,
 			);
 		}
 

--- a/includes/class-performance-wizard-data-source-lighthouse.php
+++ b/includes/class-performance-wizard-data-source-lighthouse.php
@@ -16,27 +16,57 @@ class Performance_Wizard_Data_Source_Lighthouse extends Performance_Wizard_Data_
 	public function __construct() {
 		parent::__construct();
 		$this->set_name( 'Lighthouse' );
-		$this->set_prompt( 'Gathering Lighthouse data for the site, this may take a moment.' );
-		$this->set_description( "Lighthouse is an open-source, automated tool for measuring web page quality, including performance. This data point is the Lighthouse 'performance' category result for the site's home page, fetched from the Google PageSpeed Insights API. It contains lab metrics (such as First Contentful Paint, Largest Contentful Paint, Total Blocking Time, Cumulative Layout Shift, and Speed Index), an overall performance score, and the individual performance audits with their scores and details. Note that base64-encoded inline image data has been stripped and replaced with the placeholder 'BINARY_DATA_REMOVED' to keep the payload small, so do not treat that placeholder as a finding. This page describes how Lighthouse weighs its performance score: https://developer.chrome.com/docs/lighthouse/performance/performance-scoring." );
-		$this->set_analysis_strategy( 'The response shape is documented here: https://developers.google.com/speed/docs/insights/v5/reference/pagespeedapi/runpagespeed#response. Start from the overall performance score and the failing or low-scoring audits, since these indicate the highest-impact opportunities. For each notable failing audit, name the audit and the specific items it flags (URLs, scripts, images, or DOM nodes) and quantify the potential savings the audit reports. The site is a WordPress site, so look for WordPress-specific causes; assets served from a plugin or theme include the slug in their path (typically /wp-content/plugins/{slug}/... or /wp-content/themes/{slug}/...), which you should use to attribute issues to a specific plugin or theme in this and later steps. If the response includes a loadingExperience or originLoadingExperience field, that is real-user (CrUX) field data - compare it against the lab metrics and call out meaningful divergence, but do not assume field data is present if those fields are absent.' );
-		$this->set_data_shape( 'The results include the `lighthouseResult` object which is a Lighthouse Results Object (LHR), documented here: https://github.com/GoogleChrome/lighthouse/blob/main/docs/understanding-results.md. The object structure for the audits is described here: https://github.com/GoogleChrome/lighthouse/blob/main/docs/understanding-results.md#audits. The audits themselves are open source audits run against the page and available for review here: https://github.com/GoogleChrome/lighthouse/tree/main/core/audits.' );
+		$this->set_prompt( 'Gathering Lighthouse data for each selected page type, this may take a moment per page type.' );
+		$this->set_description( "Lighthouse is an open-source, automated tool for measuring web page quality, including performance. This data point contains the Lighthouse 'performance' category result fetched from the Google PageSpeed Insights API for one or more page types on the site, controlled by the plugin's Page Types setting (home page, posts archive, and/or most recently published post). Each result contains lab metrics (such as First Contentful Paint, Largest Contentful Paint, Total Blocking Time, Cumulative Layout Shift, and Speed Index), an overall performance score, and the individual performance audits with their scores and details. Note that base64-encoded inline image data has been stripped and replaced with the placeholder 'BINARY_DATA_REMOVED' to keep the payload small, so do not treat that placeholder as a finding. This page describes how Lighthouse weighs its performance score: https://developer.chrome.com/docs/lighthouse/performance/performance-scoring." );
+		$this->set_analysis_strategy( 'The PageSpeed Insights response shape is documented here: https://developers.google.com/speed/docs/insights/v5/reference/pagespeedapi/runpagespeed#response. Start from the overall performance score and the failing or low-scoring audits, since these indicate the highest-impact opportunities. For each notable failing audit, name the audit and the specific items it flags (URLs, scripts, images, or DOM nodes) and quantify the potential savings the audit reports. The site is a WordPress site, so look for WordPress-specific causes; assets served from a plugin or theme include the slug in their path (typically /wp-content/plugins/{slug}/... or /wp-content/themes/{slug}/...), which you should use to attribute issues to a specific plugin or theme in this and later steps. If a result includes a loadingExperience or originLoadingExperience field, that is real-user (CrUX) field data - compare it against the lab metrics and call out meaningful divergence, but do not assume field data is present if those fields are absent. When more than one page type is included, compare scores and failing audits across page types and call out template-specific regressions or improvements, attributing each finding to the specific page type label.' );
+		$this->set_data_shape( 'The data is a JSON object whose keys are the selected page type slugs ("home", "archive", and/or "post"). Each value is an object with three fields: "url" (the URL analyzed), "label" (a short human-readable name for the page type), and "result" - the raw PageSpeed Insights API response for that URL. The PSI response includes the `lighthouseResult` object which is a Lighthouse Results Object (LHR), documented here: https://github.com/GoogleChrome/lighthouse/blob/main/docs/understanding-results.md. The object structure for the audits is described here: https://github.com/GoogleChrome/lighthouse/blob/main/docs/understanding-results.md#audits. The audits themselves are open source audits run against the page and available for review here: https://github.com/GoogleChrome/lighthouse/tree/main/core/audits. When a URL could not be resolved or the API request failed, "result" is an object with a single "error" field describing the problem.' );
 	}
 
 		/**
-		 * Get the data from Lighthouse.
+		 * Get the Lighthouse data for each selected page type.
 		 *
-		 * @return mixed The data from the data source.
+		 * @return string JSON encoded string of the multi-page Lighthouse data.
 		 */
-	public function get_data() {
-		// Get the data from the PageSpeed Insights API.
-		$site_url     = apply_filters( 'wp_performance_wizard_site_url', get_site_url() );
+	public function get_data(): string {
+		$page_types = Performance_Wizard_Settings_Page::page_types();
+		$collected  = array();
+
+		foreach ( $page_types as $page_type ) {
+			$url   = Performance_Wizard_Settings_Page::get_page_type_url( $page_type );
+			$label = isset( Performance_Wizard_Settings_Page::SUPPORTED_PAGE_TYPES[ $page_type ] )
+				? Performance_Wizard_Settings_Page::SUPPORTED_PAGE_TYPES[ $page_type ]
+				: $page_type;
+
+			$collected[ $page_type ] = array(
+				'url'    => $url,
+				'label'  => $label,
+				'result' => '' === $url
+					? array( 'error' => 'No URL could be resolved for this page type.' )
+					: $this->fetch_lighthouse_for_url( $url ),
+			);
+		}
+
+		$encoded = wp_json_encode( $collected );
+		return false === $encoded ? '{}' : $encoded;
+	}
+
+	/**
+	 * Fetch the raw PageSpeed Insights response for a single URL.
+	 *
+	 * Returns the decoded array on success and an `{error: string}` array when
+	 * the call fails, so the multi-URL caller can continue with the remaining
+	 * page types.
+	 *
+	 * @param string $url The URL to analyze.
+	 *
+	 * @return array<string,mixed> Decoded PSI response, or an error array.
+	 */
+	private function fetch_lighthouse_for_url( string $url ): array {
 		$api_base     = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed';
 		$query_params = array(
-			'url'      => $site_url,
+			'url'      => $url,
 			'category' => 'performance',
 		);
-
-		// Log this request.
 
 		$response = wp_remote_get(
 			add_query_arg( $query_params, $api_base ),
@@ -45,21 +75,21 @@ class Performance_Wizard_Data_Source_Lighthouse extends Performance_Wizard_Data_
 			)
 		);
 
-		// Check for errors.
 		if ( is_wp_error( $response ) ) {
-
-			return $response;
+			return array( 'error' => $response->get_error_message() );
 		}
 
-		// Return the data.
-		$results = wp_remote_retrieve_body( $response );
+		$body = wp_remote_retrieve_body( $response );
 
-		// Remove binary image blobs starting with "data:image/*"".
-		// User a regex to replace all instances of the pattern. Replace with a placeholder.
-		$results = preg_replace( '/(data:image\/[^"]*)/', 'BINARY_DATA_REMOVED', $results );
+		// Remove base64-encoded inline image blobs to keep the payload small.
+		$cleaned = preg_replace( '/(data:image\/[^"]*)/', 'BINARY_DATA_REMOVED', $body );
+		$body    = is_string( $cleaned ) ? $cleaned : $body;
 
-		// Log the results.
+		$decoded = json_decode( $body, true );
+		if ( ! is_array( $decoded ) ) {
+			return array( 'error' => 'Could not decode PageSpeed Insights response for ' . $url );
+		}
 
-		return $results;
+		return $decoded;
 	}
 }

--- a/includes/class-performance-wizard-settings-page.php
+++ b/includes/class-performance-wizard-settings-page.php
@@ -158,29 +158,40 @@ class Performance_Wizard_Settings_Page {
 	 * @return string The URL, or an empty string when unresolved.
 	 */
 	public static function get_page_type_url( string $page_type ): string {
+		$url = '';
+
 		switch ( $page_type ) {
 			case 'home':
-				/**
-				 * Filter the site URL used for performance wizard analysis.
-				 *
-				 * @param string $site_url The site URL.
-				 * @return string The filtered site URL.
-				 */
-				return apply_filters( 'wp_performance_wizard_site_url', get_site_url() );
+				$url = get_site_url();
+				break;
 
 			case 'post':
 				$posts = get_posts( array( 'numberposts' => 1 ) );
-				if ( 0 === count( $posts ) ) {
-					return '';
+				if ( count( $posts ) > 0 ) {
+					$permalink = get_permalink( $posts[0]->ID );
+					$url       = is_string( $permalink ) ? $permalink : '';
 				}
-				$permalink = get_permalink( $posts[0]->ID );
-				return is_string( $permalink ) ? $permalink : '';
+				break;
 
 			case 'archive':
-				$url = get_post_type_archive_link( 'post' );
-				return is_string( $url ) ? $url : '';
+				$archive = get_post_type_archive_link( 'post' );
+				$url     = is_string( $archive ) ? $archive : '';
+				break;
 		}
-		return '';
+
+		/**
+		 * Filter the URL used for performance wizard analysis.
+		 *
+		 * Use this to point the wizard at a staging URL or override the URL
+		 * resolved for a specific page type before it is fetched. The filter
+		 * runs for every supported page type so staging-site overrides cover
+		 * the home page, the posts archive, and individual post permalinks.
+		 *
+		 * @param string $url       The resolved URL, or an empty string when none could be resolved.
+		 * @param string $page_type The page type slug being resolved (one of the SUPPORTED_PAGE_TYPES keys).
+		 * @return string The filtered URL.
+		 */
+		return apply_filters( 'wp_performance_wizard_site_url', $url, $page_type );
 	}
 
 	/**

--- a/includes/class-performance-wizard-settings-page.php
+++ b/includes/class-performance-wizard-settings-page.php
@@ -25,6 +25,20 @@ class Performance_Wizard_Settings_Page {
 	const SUPPORTED_LANGUAGES = array( 'php', 'js', 'css', 'html' );
 
 	/**
+	 * Page types that the URL-dependent data sources can analyze.
+	 *
+	 * Keyed by the slug stored in the option, with a human-readable label as
+	 * the value.
+	 *
+	 * @var array<string,string>
+	 */
+	const SUPPORTED_PAGE_TYPES = array(
+		'home'    => 'Home page',
+		'archive' => 'Posts archive',
+		'post'    => 'Most recent post',
+	);
+
+	/**
 	 * Wire up admin hooks.
 	 */
 	public function __construct() {
@@ -57,6 +71,7 @@ class Performance_Wizard_Settings_Page {
 			'collect_plugin_sources'  => false,
 			'plugin_source_languages' => array( 'php' ),
 			'use_expert_skills'       => true,
+			'page_types'              => array( 'home' ),
 		);
 		if ( ! is_array( $stored ) ) {
 			$stored = array();
@@ -106,6 +121,69 @@ class Performance_Wizard_Settings_Page {
 	}
 
 	/**
+	 * The page types that URL-dependent data sources (Lighthouse, HTML) should
+	 * analyze on each run.
+	 *
+	 * Filterable via `wp_performance_wizard_page_types`. Always constrained to
+	 * SUPPORTED_PAGE_TYPES; if filtering yields an empty list, falls back to
+	 * `home` to guarantee at least one URL.
+	 *
+	 * @return string[] The selected page type slugs.
+	 */
+	public static function page_types(): array {
+		$options    = self::get_options();
+		$page_types = is_array( $options['page_types'] ) ? $options['page_types'] : array( 'home' );
+		/**
+		 * Filters the list of page types to analyze.
+		 *
+		 * @param mixed $page_types Current list from settings (string[]).
+		 */
+		$page_types = apply_filters( 'wp_performance_wizard_page_types', $page_types );
+		if ( ! is_array( $page_types ) ) {
+			$page_types = array( 'home' );
+		}
+		$page_types = array_map( 'sanitize_key', $page_types );
+		$page_types = array_values( array_intersect( array_keys( self::SUPPORTED_PAGE_TYPES ), $page_types ) );
+		return 0 === count( $page_types ) ? array( 'home' ) : $page_types;
+	}
+
+	/**
+	 * Resolve the URL to fetch for a given page type slug.
+	 *
+	 * Returns an empty string when a representative URL cannot be resolved
+	 * (for example, no published posts yet).
+	 *
+	 * @param string $page_type One of the SUPPORTED_PAGE_TYPES keys.
+	 *
+	 * @return string The URL, or an empty string when unresolved.
+	 */
+	public static function get_page_type_url( string $page_type ): string {
+		switch ( $page_type ) {
+			case 'home':
+				/**
+				 * Filter the site URL used for performance wizard analysis.
+				 *
+				 * @param string $site_url The site URL.
+				 * @return string The filtered site URL.
+				 */
+				return apply_filters( 'wp_performance_wizard_site_url', get_site_url() );
+
+			case 'post':
+				$posts = get_posts( array( 'numberposts' => 1 ) );
+				if ( 0 === count( $posts ) ) {
+					return '';
+				}
+				$permalink = get_permalink( $posts[0]->ID );
+				return is_string( $permalink ) ? $permalink : '';
+
+			case 'archive':
+				$url = get_post_type_archive_link( 'post' );
+				return is_string( $url ) ? $url : '';
+		}
+		return '';
+	}
+
+	/**
 	 * Render the settings page.
 	 */
 	public function render_page(): void {
@@ -113,10 +191,11 @@ class Performance_Wizard_Settings_Page {
 			return;
 		}
 
-		$options            = self::get_options();
-		$collect_enabled    = (bool) $options['collect_plugin_sources'];
-		$selected_languages = (array) $options['plugin_source_languages'];
-		$skills_enabled     = (bool) $options['use_expert_skills'];
+		$options             = self::get_options();
+		$collect_enabled     = (bool) $options['collect_plugin_sources'];
+		$selected_languages  = (array) $options['plugin_source_languages'];
+		$skills_enabled      = (bool) $options['use_expert_skills'];
+		$selected_page_types = (array) $options['page_types'];
 
 		$notice = isset( $_GET['info'] ) ? sanitize_key( wp_unslash( $_GET['info'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
@@ -159,6 +238,21 @@ class Performance_Wizard_Settings_Page {
 		echo '<p class="description">' . esc_html__( 'PHP is recommended for the best signal-to-cost ratio. All file types are capped by size to keep prompt size manageable.', 'wp-performance-wizard' ) . '</p>';
 		echo '</fieldset></td></tr>';
 
+		echo '</tbody></table>';
+
+		echo '<h2>' . esc_html__( 'Page Types to Analyze', 'wp-performance-wizard' ) . '</h2>';
+		echo '<p>' . esc_html__( 'Performance characteristics differ between templates. The URL-dependent data sources (Lighthouse, HTML) will run against each selected page type and label the results so the AI can compare template-specific issues. Selecting more page types increases analysis time and Lighthouse API usage.', 'wp-performance-wizard' ) . '</p>';
+		echo '<table class="form-table" role="presentation"><tbody>';
+		echo '<tr><th scope="row">' . esc_html__( 'Page types', 'wp-performance-wizard' ) . '</th><td><fieldset>';
+		echo '<legend class="screen-reader-text">' . esc_html__( 'Page types', 'wp-performance-wizard' ) . '</legend>';
+		foreach ( self::SUPPORTED_PAGE_TYPES as $page_type => $label ) {
+			$checked = in_array( $page_type, $selected_page_types, true );
+			echo '<label style="margin-right:1em;"><input type="checkbox" name="page_types[]" value="' . esc_attr( $page_type ) . '"' . checked( $checked, true, false ) . '> ';
+			echo esc_html( $label );
+			echo '</label>';
+		}
+		echo '<p class="description">' . esc_html__( 'Home page is selected by default. Archive and Most recent post may not resolve to a URL on a brand-new site with no published posts.', 'wp-performance-wizard' ) . '</p>';
+		echo '</fieldset></td></tr>';
 		echo '</tbody></table>';
 
 		echo '<h2>' . esc_html__( 'Expert Reference Skills', 'wp-performance-wizard' ) . '</h2>';
@@ -217,10 +311,24 @@ class Performance_Wizard_Settings_Page {
 
 		$skills_enabled = isset( $_POST['use_expert_skills'] );
 
+		$submitted_page_types = array();
+		if ( isset( $_POST['page_types'] ) && is_array( $_POST['page_types'] ) ) {
+			foreach ( wp_unslash( $_POST['page_types'] ) as $page_type ) {
+				$page_type = sanitize_key( (string) $page_type );
+				if ( isset( self::SUPPORTED_PAGE_TYPES[ $page_type ] ) ) {
+					$submitted_page_types[] = $page_type;
+				}
+			}
+		}
+		if ( 0 === count( $submitted_page_types ) ) {
+			$submitted_page_types = array( 'home' );
+		}
+
 		$options                            = self::get_options();
 		$options['collect_plugin_sources']  = $collect;
 		$options['plugin_source_languages'] = array_values( array_unique( $submitted_languages ) );
 		$options['use_expert_skills']       = $skills_enabled;
+		$options['page_types']              = array_values( array_unique( $submitted_page_types ) );
 
 		update_option( self::OPTION_NAME, $options );
 


### PR DESCRIPTION
## Summary

Closes [#66](https://github.com/adamsilverstein/wp-performance-wizard/issues/66).

Make the set of page types analyzed by the URL-dependent data sources (Lighthouse and HTML) user-selectable. Each result is labeled with the page type so the AI can compare templates and call out template-specific issues.

## What changed

- New **Page Types to Analyze** section on the Settings page with checkboxes for **Home page**, **Posts archive**, and **Most recent post**.
- New `page_types` option on the existing `wp_performance_wizard_options` array. Defaults to `['home']` to keep Lighthouse API cost low on a fresh install; users opt in to additional page types and accept the longer analysis time.
- New `wp_performance_wizard_page_types` filter so other code can override the selection.
- Centralized URL resolution in `Performance_Wizard_Settings_Page::get_page_type_url()` so all data sources share the same logic (and the same `wp_performance_wizard_site_url` filter for the home page).
- Lighthouse data source now loops over the selected page types, decodes each PSI response into an `{url, label, result}` triple, and continues past per-URL failures with an `{error}` payload.
- HTML data source now loops over the selected page types, returning an `{url, label, html}` triple per page.
- Updated `data_shape` and `analysis_strategy` strings on both data sources so the AI knows the shape now varies and is instructed to compare across page types when more than one is included.

## Behaviour note

The previous HTML data source unconditionally fetched all three page types. Under the new default it fetches the home page only. Users who want the older multi-page HTML can enable the additional checkboxes on the Settings page. This is called out in the PR title and commit message because it is a visible behavior change for existing installs.

## Test plan

- [ ] Visit **Tools → Performance Wizard → Settings**, confirm the new **Page Types to Analyze** section is rendered with **Home page** checked by default.
- [ ] Save with all three page types selected; verify the option round-trips after reload.
- [ ] Run a fresh analysis with only **Home page** selected; verify the HTML and Lighthouse steps each return a single page type and the AI's analysis treats it as such.
- [ ] Run a fresh analysis with **Home page**, **Posts archive**, and **Most recent post** all selected; verify the AI's analysis compares across page types and calls out template-specific issues.
- [ ] On a brand-new install with no posts, select **Most recent post** and verify the data source returns the `error` shape instead of blowing up.
- [ ] Confirm `composer lint` and `composer phpstan` still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added page type selection in settings, enabling analysis of home page, archive page, and/or individual post pages.
  * Performance wizard now generates results for each selected page type rather than analyzing only the home page.
  * Results are organized by page type for comparison.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamsilverstein/wp-performance-wizard/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->