### PR TITLE
Track recommendations as an actionable checklist

### DIFF
--- a/includes/class-performance-wizard-analysis-plan.php
+++ b/includes/class-performance-wizard-analysis-plan.php
@@ -246,6 +246,21 @@ Important: Do not provide generic recommendations like "consider adding caching"
 
 Next, provide a testing strategy for measuring the impact of the recommendations.
 
+After the prose recommendations, also include a fenced JSON code block (using triple backticks and the language tag `json`) that lists the same recommendations in a structured form so the UI can render them as a checklist. The block MUST be valid JSON of this exact shape:
+```json
+{
+  "recommendations": [
+    {
+      "title": "Short imperative title, max 80 characters",
+      "rationale": "One concise sentence explaining the recommendation.",
+      "audit": "The specific Lighthouse audit ID or problem this addresses, or an empty string when not applicable.",
+      "plugin": "The specific plugin or theme involved, or an empty string when not applicable."
+    }
+  ]
+}
+```
+Do not invent recommendations only to fill the JSON; the JSON entries must correspond 1:1 to the prose recommendations above. Output the JSON block in addition to, not instead of, the prose recommendations.
+
 Finally, based on the data collected and recommendations so far, provide two unique suggestions for follow up questions the user can ask that are for performance related. These questions should help them the user more information or further recommendations, provide more details or drill down to a specific issue. For these questions, provide them as HTML buttons that the user can click to ask the question. Keep the questions succinct, a maximum of 16 words. For example:"<button class="wp-wizard-follow-up-question">What is LCP image and how can I fix it?</button>" or "<button class="wp-wizard-follow-up-question">What is the most impactful blocking script?</button>"',
 			'display_prompt' => 'Considering all of the analysis of the previous steps, provide recommendations for improving the performance of the site including a testing strategy for measuring the impact of the recommendations.',
 			'source'         => null,

--- a/includes/css/wp-performance-wizard.css
+++ b/includes/css/wp-performance-wizard.css
@@ -190,3 +190,76 @@ button#performance-wizard-ask {
 .performance-wizard-export-bar .performance-wizard-export-button {
 	margin-right: 6px;
 }
+
+.performance-wizard-checklist {
+	margin: 16px 0;
+	padding: 14px 18px;
+	background: #fff;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+}
+
+.performance-wizard-checklist-title {
+	margin: 0 0 6px;
+	font-size: 16px;
+}
+
+.performance-wizard-checklist-help {
+	margin: 0 0 12px;
+	color: #50575e;
+	font-size: 13px;
+}
+
+.performance-wizard-checklist-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.performance-wizard-checklist-item {
+	border-top: 1px solid #f0f0f1;
+	padding: 10px 0;
+}
+
+.performance-wizard-checklist-item:first-child {
+	border-top: 0;
+}
+
+.performance-wizard-checklist-label {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	font-weight: 600;
+	cursor: pointer;
+}
+
+.performance-wizard-checklist-checkbox {
+	margin-top: 3px;
+	flex: 0 0 auto;
+}
+
+.performance-wizard-checklist-item-title {
+	flex: 1 1 auto;
+}
+
+.performance-wizard-checklist-item.is-done .performance-wizard-checklist-item-title {
+	text-decoration: line-through;
+	color: #50575e;
+}
+
+.performance-wizard-checklist-rationale {
+	margin: 4px 0 0 26px;
+	color: #1d2327;
+	font-size: 13px;
+}
+
+.performance-wizard-checklist-meta {
+	margin: 2px 0 0 26px;
+	color: #50575e;
+	font-size: 12px;
+	font-style: italic;
+}
+
+.performance-wizard-checklist-retest {
+	margin: 6px 0 0 26px;
+}

--- a/includes/js/wp-performance-wizard.js
+++ b/includes/js/wp-performance-wizard.js
@@ -1073,7 +1073,7 @@
 	 * @returns {string} The site key.
 	 */
 	function checklistSiteKey() {
-		const siteUrl = ( wpPerformanceWizard && wpPerformanceWizard.siteUrl ) || '';
+		const siteUrl = ( 'undefined' !== typeof wpPerformanceWizard && wpPerformanceWizard.siteUrl ) || '';
 		return siteUrl || '__no_site_url__';
 	}
 
@@ -1136,12 +1136,12 @@
 
 		const heading = document.createElement( 'h3' );
 		heading.className = 'performance-wizard-checklist-title';
-		heading.textContent = 'Recommendations checklist';
+		heading.textContent = __( 'Recommendations checklist', 'wp-performance-wizard' );
 		wrap.appendChild( heading );
 
 		const help = document.createElement( 'p' );
 		help.className = 'performance-wizard-checklist-help';
-		help.textContent = 'Track which recommendations you have applied. Completion state is saved locally in your browser for this site.';
+		help.textContent = __( 'Track which recommendations you have applied. Completion state is saved locally in your browser for this site.', 'wp-performance-wizard' );
 		wrap.appendChild( help );
 
 		const list = document.createElement( 'ul' );
@@ -1179,10 +1179,18 @@
 
 			const meta = [];
 			if ( item.audit ) {
-				meta.push( 'Audit: ' + String( item.audit ) );
+				meta.push( sprintf(
+					/* translators: %s: Lighthouse audit name. */
+					__( 'Audit: %s', 'wp-performance-wizard' ),
+					String( item.audit )
+				) );
 			}
 			if ( item.plugin ) {
-				meta.push( 'Plugin/theme: ' + String( item.plugin ) );
+				meta.push( sprintf(
+					/* translators: %s: plugin or theme slug. */
+					__( 'Plugin/theme: %s', 'wp-performance-wizard' ),
+					String( item.plugin )
+				) );
 			}
 			if ( meta.length ) {
 				const metaEl = document.createElement( 'p' );
@@ -1194,7 +1202,7 @@
 			const retest = document.createElement( 'button' );
 			retest.type = 'button';
 			retest.className = 'button button-secondary performance-wizard-checklist-retest';
-			retest.textContent = 'Re-test';
+			retest.textContent = __( 'Re-test', 'wp-performance-wizard' );
 			retest.style.display = done ? 'inline-block' : 'none';
 			retest.addEventListener( 'click', function() {
 				askChecklistFollowUp( item );
@@ -1237,7 +1245,11 @@
 			return;
 		}
 		const title = String( item.title || '' );
-		input.value = 'I implemented this recommendation: "' + title + '". Based on the data already gathered, how should I verify the change is working and what specific metrics should improve?';
+		input.value = sprintf(
+			/* translators: %s: the recommendation title. */
+			__( 'I implemented this recommendation: "%s". Based on the data already gathered, how should I verify the change is working and what specific metrics should improve?', 'wp-performance-wizard' ),
+			title
+		);
 		askBtn.click();
 	}
 } )();

--- a/includes/js/wp-performance-wizard.js
+++ b/includes/js/wp-performance-wizard.js
@@ -741,7 +741,7 @@
 			// If this entry is the final recommendations block and embeds a
 			// structured JSON list, render a checklist below it.
 			if ( 'recommendations' === entry.type ) {
-				renderRecommendationsChecklist( terminal, String( entry.content || '' ) );
+				renderRecommendationsChecklist( terminal, String( entry.content || '' ), { readOnly: true } );
 			}
 		} );
 	}
@@ -1122,12 +1122,20 @@
 	 *
 	 * @param {HTMLElement} container       The element to append the checklist to.
 	 * @param {string}      responseMarkdown The full AI response Markdown.
+	 * @param {Object}      [options]        Render options. Pass { readOnly: true }
+	 *                                       from the history view so checkboxes
+	 *                                       and the Re-test button are inert
+	 *                                       (archived sessions cannot mutate
+	 *                                       completion state or trigger live
+	 *                                       follow-up questions).
 	 */
-	function renderRecommendationsChecklist( container, responseMarkdown ) {
+	function renderRecommendationsChecklist( container, responseMarkdown, options ) {
 		const items = extractRecommendationsJson( responseMarkdown );
 		if ( ! container || 0 === items.length ) {
 			return;
 		}
+
+		const readOnly = !! ( options && options.readOnly );
 
 		const state = readChecklistState();
 
@@ -1161,6 +1169,9 @@
 			checkbox.type = 'checkbox';
 			checkbox.className = 'performance-wizard-checklist-checkbox';
 			checkbox.checked = done;
+			if ( readOnly ) {
+				checkbox.disabled = true;
+			}
 			label.appendChild( checkbox );
 
 			const titleSpan = document.createElement( 'span' );
@@ -1199,29 +1210,32 @@
 				li.appendChild( metaEl );
 			}
 
-			const retest = document.createElement( 'button' );
-			retest.type = 'button';
-			retest.className = 'button button-secondary performance-wizard-checklist-retest';
-			retest.textContent = __( 'Re-test', 'wp-performance-wizard' );
-			retest.style.display = done ? 'inline-block' : 'none';
-			retest.addEventListener( 'click', function() {
-				askChecklistFollowUp( item );
-			} );
-			li.appendChild( retest );
+			let retest = null;
+			if ( ! readOnly ) {
+				retest = document.createElement( 'button' );
+				retest.type = 'button';
+				retest.className = 'button button-secondary performance-wizard-checklist-retest';
+				retest.textContent = __( 'Re-test', 'wp-performance-wizard' );
+				retest.style.display = done ? 'inline-block' : 'none';
+				retest.addEventListener( 'click', function() {
+					askChecklistFollowUp( item );
+				} );
+				li.appendChild( retest );
 
-			checkbox.addEventListener( 'change', function() {
-				const newState = readChecklistState();
-				if ( checkbox.checked ) {
-					newState[ key ] = true;
-					li.classList.add( 'is-done' );
-					retest.style.display = 'inline-block';
-				} else {
-					delete newState[ key ];
-					li.classList.remove( 'is-done' );
-					retest.style.display = 'none';
-				}
-				writeChecklistState( newState );
-			} );
+				checkbox.addEventListener( 'change', function() {
+					const newState = readChecklistState();
+					if ( checkbox.checked ) {
+						newState[ key ] = true;
+						li.classList.add( 'is-done' );
+						retest.style.display = 'inline-block';
+					} else {
+						delete newState[ key ];
+						li.classList.remove( 'is-done' );
+						retest.style.display = 'none';
+					}
+					writeChecklistState( newState );
+				} );
+			}
 
 			list.appendChild( li );
 		} );

--- a/includes/js/wp-performance-wizard.js
+++ b/includes/js/wp-performance-wizard.js
@@ -391,6 +391,10 @@
 						echoToTerminal( '<div class="dc">' + ( result || '' ) + '</div>' );
 					}
 
+					// If the response includes a structured recommendations
+					// block, render it as a checklist below the prose.
+					renderRecommendationsChecklist( terminal, result || '' );
+
 					break;
 				case 'continue':
 					step++;
@@ -733,6 +737,12 @@
 			body.className = 'dc';
 			body.innerHTML = marked.marked( String( entry.content || '' ) );
 			terminal.appendChild( body );
+
+			// If this entry is the final recommendations block and embeds a
+			// structured JSON list, render a checklist below it.
+			if ( 'recommendations' === entry.type ) {
+				renderRecommendationsChecklist( terminal, String( entry.content || '' ) );
+			}
 		} );
 	}
 
@@ -996,5 +1006,238 @@
 			return false;
 		}
 		return ! /^(javascript|data|vbscript|file):/i.test( trimmed );
+	}
+
+	/**
+	 * The localStorage key used to persist completed recommendation state.
+	 *
+	 * The shape is { "<site-url>": { "<lowercased trimmed title>": true } } so
+	 * different WP installs viewed from the same browser do not collide.
+	 *
+	 * @constant {string}
+	 */
+	const CHECKLIST_STORAGE_KEY = 'wp-performance-wizard-recommendations-checklist';
+
+	/**
+	 * Read the stored "done" state map for the current site.
+	 *
+	 * @returns {Object<string,boolean>} Title-keyed completion state.
+	 */
+	function readChecklistState() {
+		try {
+			const raw = window.localStorage.getItem( CHECKLIST_STORAGE_KEY );
+			if ( ! raw ) {
+				return {};
+			}
+			const parsed = JSON.parse( raw );
+			const siteKey = checklistSiteKey();
+			if ( parsed && 'object' === typeof parsed && parsed[ siteKey ] && 'object' === typeof parsed[ siteKey ] ) {
+				return parsed[ siteKey ];
+			}
+		} catch ( e ) {
+			// Storage may be unavailable (private mode, quota); start fresh.
+		}
+		return {};
+	}
+
+	/**
+	 * Persist the "done" state map for the current site.
+	 *
+	 * @param {Object<string,boolean>} state Title-keyed completion state.
+	 */
+	function writeChecklistState( state ) {
+		try {
+			const raw = window.localStorage.getItem( CHECKLIST_STORAGE_KEY );
+			let parsed = {};
+			if ( raw ) {
+				try {
+					const candidate = JSON.parse( raw );
+					if ( candidate && 'object' === typeof candidate ) {
+						parsed = candidate;
+					}
+				} catch ( e ) {
+					parsed = {};
+				}
+			}
+			parsed[ checklistSiteKey() ] = state;
+			window.localStorage.setItem( CHECKLIST_STORAGE_KEY, JSON.stringify( parsed ) );
+		} catch ( e ) {
+			// Storage write failed; tolerate silently.
+		}
+	}
+
+	/**
+	 * Stable per-site key for checklist state. Falls back to a sentinel when no
+	 * site URL is available (older configurations or test environments).
+	 *
+	 * @returns {string} The site key.
+	 */
+	function checklistSiteKey() {
+		const siteUrl = ( wpPerformanceWizard && wpPerformanceWizard.siteUrl ) || '';
+		return siteUrl || '__no_site_url__';
+	}
+
+	/**
+	 * Normalize a recommendation title so the same recommendation matches across runs.
+	 *
+	 * @param {string} title The raw title.
+	 * @returns {string} A normalized key.
+	 */
+	function normalizeChecklistTitle( title ) {
+		return String( title || '' ).trim().toLowerCase();
+	}
+
+	/**
+	 * Extract the structured recommendations from a Markdown response.
+	 *
+	 * Looks for a fenced JSON code block (```json ... ```) anywhere in the
+	 * response and returns the `recommendations` array from it. Returns an
+	 * empty array when the block is missing or unparsable.
+	 *
+	 * @param {string} markdown The raw response Markdown.
+	 * @returns {Array<{title:string,rationale:string,audit:string,plugin:string}>}
+	 */
+	function extractRecommendationsJson( markdown ) {
+		const source = String( markdown || '' );
+		const match = source.match( /```\s*json\s*([\s\S]*?)```/i );
+		if ( ! match ) {
+			return [];
+		}
+		try {
+			const parsed = JSON.parse( match[1] );
+			if ( parsed && Array.isArray( parsed.recommendations ) ) {
+				return parsed.recommendations.filter( function( item ) {
+					return item && 'object' === typeof item && item.title;
+				} );
+			}
+		} catch ( e ) {
+			// JSON block was present but invalid; skip the checklist UI.
+		}
+		return [];
+	}
+
+	/**
+	 * Render a checkable list of recommendations into the given container if
+	 * the response includes a structured JSON block. No-op otherwise.
+	 *
+	 * @param {HTMLElement} container       The element to append the checklist to.
+	 * @param {string}      responseMarkdown The full AI response Markdown.
+	 */
+	function renderRecommendationsChecklist( container, responseMarkdown ) {
+		const items = extractRecommendationsJson( responseMarkdown );
+		if ( ! container || 0 === items.length ) {
+			return;
+		}
+
+		const state = readChecklistState();
+
+		const wrap = document.createElement( 'div' );
+		wrap.className = 'performance-wizard-checklist';
+
+		const heading = document.createElement( 'h3' );
+		heading.className = 'performance-wizard-checklist-title';
+		heading.textContent = 'Recommendations checklist';
+		wrap.appendChild( heading );
+
+		const help = document.createElement( 'p' );
+		help.className = 'performance-wizard-checklist-help';
+		help.textContent = 'Track which recommendations you have applied. Completion state is saved locally in your browser for this site.';
+		wrap.appendChild( help );
+
+		const list = document.createElement( 'ul' );
+		list.className = 'performance-wizard-checklist-list';
+
+		items.forEach( function( item ) {
+			const key = normalizeChecklistTitle( item.title );
+			const done = !! state[ key ];
+
+			const li = document.createElement( 'li' );
+			li.className = 'performance-wizard-checklist-item' + ( done ? ' is-done' : '' );
+
+			const label = document.createElement( 'label' );
+			label.className = 'performance-wizard-checklist-label';
+
+			const checkbox = document.createElement( 'input' );
+			checkbox.type = 'checkbox';
+			checkbox.className = 'performance-wizard-checklist-checkbox';
+			checkbox.checked = done;
+			label.appendChild( checkbox );
+
+			const titleSpan = document.createElement( 'span' );
+			titleSpan.className = 'performance-wizard-checklist-item-title';
+			titleSpan.textContent = String( item.title );
+			label.appendChild( titleSpan );
+
+			li.appendChild( label );
+
+			if ( item.rationale ) {
+				const rationale = document.createElement( 'p' );
+				rationale.className = 'performance-wizard-checklist-rationale';
+				rationale.textContent = String( item.rationale );
+				li.appendChild( rationale );
+			}
+
+			const meta = [];
+			if ( item.audit ) {
+				meta.push( 'Audit: ' + String( item.audit ) );
+			}
+			if ( item.plugin ) {
+				meta.push( 'Plugin/theme: ' + String( item.plugin ) );
+			}
+			if ( meta.length ) {
+				const metaEl = document.createElement( 'p' );
+				metaEl.className = 'performance-wizard-checklist-meta';
+				metaEl.textContent = meta.join( ' · ' );
+				li.appendChild( metaEl );
+			}
+
+			const retest = document.createElement( 'button' );
+			retest.type = 'button';
+			retest.className = 'button button-secondary performance-wizard-checklist-retest';
+			retest.textContent = 'Re-test';
+			retest.style.display = done ? 'inline-block' : 'none';
+			retest.addEventListener( 'click', function() {
+				askChecklistFollowUp( item );
+			} );
+			li.appendChild( retest );
+
+			checkbox.addEventListener( 'change', function() {
+				const newState = readChecklistState();
+				if ( checkbox.checked ) {
+					newState[ key ] = true;
+					li.classList.add( 'is-done' );
+					retest.style.display = 'inline-block';
+				} else {
+					delete newState[ key ];
+					li.classList.remove( 'is-done' );
+					retest.style.display = 'none';
+				}
+				writeChecklistState( newState );
+			} );
+
+			list.appendChild( li );
+		} );
+
+		wrap.appendChild( list );
+		container.appendChild( wrap );
+	}
+
+	/**
+	 * Fill the follow-up question input with a re-test prompt and click Ask.
+	 *
+	 * No-op when the analysis is not yet in its Q&A phase (the input is only
+	 * added once the run has reached the 'complete' step).
+	 *
+	 * @param {Object} item The recommendation item being re-tested.
+	 */
+	function askChecklistFollowUp( item ) {
+		const input = document.getElementById( 'performance-wizard-question' );
+		const askBtn = document.getElementById( 'performance-wizard-ask' );
+		if ( ! input || ! askBtn ) {
+			return;
+		}
+		const title = String( item.title || '' );
+		input.value = 'I implemented this recommendation: "' + title + '". Based on the data already gathered, how should I verify the change is working and what specific metrics should improve?';
+		askBtn.click();
 	}
 } )();


### PR DESCRIPTION
## Summary

Closes [#65](https://github.com/adamsilverstein/wp-performance-wizard/issues/65).

Turn the AI's final recommendations into a checkable task list so users can mark items as completed, persist that state per site, and trigger a focused re-test follow-up question.

## How it works

- The **Summarize Results** prompt is extended to require, alongside the prose recommendations, an additional fenced \`json\` code block listing the same items as structured entries with \`title\` / \`rationale\` / \`audit\` / \`plugin\`. The prompt explicitly tells the AI not to invent new items only to fill the JSON - the entries must mirror the prose 1:1.
- After the response is rendered, the terminal JS extracts that JSON block and renders the items as a checklist below the prose response.
- Completion state is persisted in \`localStorage\` keyed by the site URL (already passed through \`wp_localize_script\` as \`wpPerformanceWizard.siteUrl\`), so the same recommendation across multiple runs picks up its prior **done** state - if the wizard surfaces the same fix again, it stays marked as completed.
- Each completed item exposes a **Re-test** button that pre-fills the follow-up question input with a focused verification prompt (\"I implemented this recommendation: ...\") and submits it, dropping the user back into the existing Q&A flow described in the issue.
- The checklist also renders inside the read-only history view: when a stored \`recommendations\` transcript entry still contains the JSON block, the same widget appears beneath it.

## Out of scope

- Server-side persistence of completion state. \`localStorage\` is sufficient for the per-site, per-browser scope described in the issue. The state survives WP plugin updates and navigation but is per-browser, which can be revisited if needed.
- Automatic verification that a fix actually worked beyond the existing compare/Q&A path - this is explicitly out of scope per the issue.

## Test plan

- [ ] Run a fresh analysis end-to-end and confirm the **Summarize Results** step now ends with both the prose recommendations and a \`json\` fenced block.
- [ ] Confirm the **Recommendations checklist** widget appears below the prose with one entry per recommendation, including rationale and audit / plugin metadata.
- [ ] Check a few items, refresh the page or start a new analysis, and confirm previously-completed titles come back checked.
- [ ] Click **Re-test** on a completed item and confirm the follow-up question input is filled with a verification prompt and submitted to the AI.
- [ ] Load a past session from the **Analysis History** panel and confirm the checklist re-renders read-only beneath the stored recommendations.
- [ ] Confirm \`composer lint\` and \`composer phpstan\` still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured recommendations checklist interface allowing users to mark completed performance improvements.
  * Introduced progress tracking that persists across sessions for monitoring recommendation completion.
  * Added a "Re-test" button to re-run analysis on specific recommendations without re-analyzing everything.
  * Enhanced styling for improved checklist visibility and user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamsilverstein/wp-performance-wizard/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->