### PR TITLE
Misc fixes: checkbox spacing, AI Client migration, HTML fetch for local sites

### DIFF
--- a/includes/class-performance-wizard-ai-agent-base.php
+++ b/includes/class-performance-wizard-ai-agent-base.php
@@ -222,7 +222,7 @@ class Performance_Wizard_AI_Agent_Base {
 	 */
 	protected function send_via_ai_client( array $prompts, int $current_step, array $previous_steps, array $options = array() ): string {
 		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-			return 'WordPress AI Client API (wp_ai_client_prompt) is unavailable. WordPress 7.0+ is required.';
+			return __( 'WordPress AI Client API (wp_ai_client_prompt) is unavailable. WordPress 7.0+ is required.', 'wp-performance-wizard' );
 		}
 
 		$history = array();
@@ -279,7 +279,8 @@ class Performance_Wizard_AI_Agent_Base {
 
 			if ( ! self::is_transient_error( $error_message ) || $attempt === $max_attempts ) {
 				error_log( sprintf( '[WP Performance Wizard][%s] generate_text failed (attempt %d/%d): %s', $this->get_name(), $attempt, $max_attempts, $error_message ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				return $this->get_name() . ' API error: ' . $error_message;
+				/* translators: 1: AI agent name (e.g. Claude), 2: error message from the AI Client. */
+				return sprintf( __( '%1$s API error: %2$s', 'wp-performance-wizard' ), $this->get_name(), $error_message );
 			}
 
 			$delay = min( 2 ** ( $attempt - 1 ), 8 );
@@ -287,7 +288,8 @@ class Performance_Wizard_AI_Agent_Base {
 			sleep( $delay );
 		}
 
-		return $this->get_name() . ' API error: maximum retries exceeded.';
+		/* translators: %s: AI agent name (e.g. Claude). */
+		return sprintf( __( '%s API error: maximum retries exceeded.', 'wp-performance-wizard' ), $this->get_name() );
 	}
 
 	/**

--- a/includes/class-performance-wizard-ai-agent-base.php
+++ b/includes/class-performance-wizard-ai-agent-base.php
@@ -202,6 +202,139 @@ class Performance_Wizard_AI_Agent_Base {
 	}
 
 	/**
+	 * Send prompts via the WordPress 7.0 AI Client API with retry-on-transient.
+	 *
+	 * Builds the prompt builder with the agent's connector ID as the provider,
+	 * the cached system instructions, prior conversation history as Message
+	 * DTOs, and an extended request timeout suitable for our large analysis
+	 * prompts. Retries up to three times with exponential backoff when the
+	 * underlying request fails with a transient error (timeouts, network
+	 * blips, rate limits, or 5xx upstream errors).
+	 *
+	 * @param array<int, string>                $prompts        Current prompts to send.
+	 * @param int                               $current_step   The current step index.
+	 * @param array<int, array<string, string>> $previous_steps Prior steps to replay as history.
+	 * @param array<string, mixed>              $options        Optional per-agent tuning:
+	 *                                                          'max_tokens'  int   default 2048,
+	 *                                                          'temperature' float omitted unless set,
+	 *                                                          'timeout'     float seconds, default 180.
+	 * @return string The model output, or a user-facing error string.
+	 */
+	protected function send_via_ai_client( array $prompts, int $current_step, array $previous_steps, array $options = array() ): string {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return 'WordPress AI Client API (wp_ai_client_prompt) is unavailable. WordPress 7.0+ is required.';
+		}
+
+		$history = array();
+		for ( $i = 1; $i < $current_step; $i++ ) {
+			if ( ! isset( $previous_steps[ $i ] ) ) {
+				continue;
+			}
+			$step = $previous_steps[ $i ];
+			if ( isset( $step['prompts'] ) && '' !== $step['prompts'] ) {
+				$history[] = new \WordPress\AiClient\Messages\DTO\Message(
+					\WordPress\AiClient\Messages\Enums\MessageRoleEnum::user(),
+					array( new \WordPress\AiClient\Messages\DTO\MessagePart( $step['prompts'] ) )
+				);
+			}
+			if ( isset( $step['response'] ) && '' !== $step['response'] ) {
+				$history[] = new \WordPress\AiClient\Messages\DTO\Message(
+					\WordPress\AiClient\Messages\Enums\MessageRoleEnum::model(),
+					array( new \WordPress\AiClient\Messages\DTO\MessagePart( $step['response'] ) )
+				);
+			}
+		}
+
+		$current_prompt = implode( PHP_EOL, $prompts );
+		$max_tokens     = isset( $options['max_tokens'] ) ? (int) $options['max_tokens'] : 2048;
+		$timeout        = isset( $options['timeout'] ) ? (float) $options['timeout'] : 180.0;
+		$max_attempts   = 3;
+
+		for ( $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
+			$builder = wp_ai_client_prompt( $current_prompt )
+				->using_provider( $this->get_connector_id() )
+				->using_system_instruction( $this->get_system_instructions() )
+				->using_max_tokens( $max_tokens )
+				->using_request_options(
+					\WordPress\AiClient\Providers\Http\DTO\RequestOptions::fromArray(
+						array( \WordPress\AiClient\Providers\Http\DTO\RequestOptions::KEY_TIMEOUT => $timeout )
+					)
+				);
+
+			if ( isset( $options['temperature'] ) ) {
+				$builder = $builder->using_temperature( (float) $options['temperature'] );
+			}
+
+			if ( count( $history ) > 0 ) {
+				$builder = $builder->with_history( ...$history );
+			}
+
+			$result = $builder->generate_text();
+
+			if ( ! is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			$error_message = $result->get_error_message();
+
+			if ( ! self::is_transient_error( $error_message ) || $attempt === $max_attempts ) {
+				error_log( sprintf( '[WP Performance Wizard][%s] generate_text failed (attempt %d/%d): %s', $this->get_name(), $attempt, $max_attempts, $error_message ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				return $this->get_name() . ' API error: ' . $error_message;
+			}
+
+			$delay = min( 2 ** ( $attempt - 1 ), 8 );
+			error_log( sprintf( '[WP Performance Wizard][%s] transient error on attempt %d/%d, retrying in %ds: %s', $this->get_name(), $attempt, $max_attempts, $delay, $error_message ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			sleep( $delay );
+		}
+
+		return $this->get_name() . ' API error: maximum retries exceeded.';
+	}
+
+	/**
+	 * Decide whether an AI Client error message represents a transient failure
+	 * that is worth retrying.
+	 *
+	 * @param string $message The error message returned by the AI Client.
+	 * @return bool Whether the request should be retried.
+	 */
+	private static function is_transient_error( string $message ): bool {
+		$lower = strtolower( $message );
+
+		$transient_markers = array(
+			'timed out',
+			'timeout',
+			'curl error 28',
+			'curl error 6',
+			'curl error 7',
+			'curl error 35',
+			'curl error 52',
+			'curl error 56',
+			'could not resolve',
+			'connection reset',
+			'connection refused',
+			'temporarily unavailable',
+			'rate limit',
+			'too many requests',
+			'overloaded',
+			' 429',
+			' 500',
+			' 502',
+			' 503',
+			' 504',
+			'http/1.1 5',
+			'http/2 5',
+		);
+
+		foreach ( $transient_markers as $marker ) {
+			if ( false !== strpos( $lower, $marker ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Load the API key for this agent from the Connectors API.
 	 *
 	 * Resolution order matches the Connectors API contract:

--- a/includes/class-performance-wizard-ai-agent-chatgpt.php
+++ b/includes/class-performance-wizard-ai-agent-chatgpt.php
@@ -2,17 +2,13 @@
 /**
  * Performance Wizard AI Agent for ChatGPT.
  *
- * This file contains the ChatGPT AI agent implementation for the WordPress Performance Wizard.
- * Requests go through the WordPress 7.0 AI Client API (wp_ai_client_prompt) so credentials
- * resolved by the Connectors API are applied automatically and model selection is delegated
- * to the registry instead of being hardcoded.
+ * Requests go through the WordPress 7.0 AI Client API via the shared
+ * Performance_Wizard_AI_Agent_Base::send_via_ai_client() helper, which adds an
+ * extended request timeout and exponential-backoff retries for transient
+ * failures. Credentials are resolved by the Connectors API.
  *
  * @package wp-performance-wizard
  */
-
-use WordPress\AiClient\Messages\DTO\Message;
-use WordPress\AiClient\Messages\DTO\MessagePart;
-use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 
 /**
  * A class that enables connections to OpenAI ChatGPT.
@@ -32,7 +28,7 @@ class Performance_Wizard_AI_Agent_ChatGPT extends Performance_Wizard_AI_Agent_Ba
 	}
 
 	/**
-	 * Send a single prompt to ChatGPT via the WordPress AI Client API.
+	 * Send a single prompt to ChatGPT.
 	 *
 	 * @param string $prompt               The prompt to pass to the agent.
 	 * @param int    $current_step         The current step in the process.
@@ -48,7 +44,7 @@ class Performance_Wizard_AI_Agent_ChatGPT extends Performance_Wizard_AI_Agent_Ba
 	}
 
 	/**
-	 * Send prompts to ChatGPT via the WordPress AI Client API.
+	 * Send prompts to ChatGPT.
 	 *
 	 * @param array $prompts              The prompts to pass to the agent.
 	 * @param int   $current_step         The current step in the process.
@@ -57,49 +53,14 @@ class Performance_Wizard_AI_Agent_ChatGPT extends Performance_Wizard_AI_Agent_Ba
 	 * @return string The response from the API.
 	 */
 	public function send_prompts( array $prompts, int $current_step, array $previous_steps, bool $additional_questions ): string {
-		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-			return 'WordPress AI Client API (wp_ai_client_prompt) is unavailable. WordPress 7.0+ is required.';
-		}
-
-		$history = array();
-		for ( $i = 1; $i < $current_step; $i++ ) {
-			if ( ! isset( $previous_steps[ $i ] ) ) {
-				continue;
-			}
-			$step = $previous_steps[ $i ];
-			if ( isset( $step['prompts'] ) && '' !== $step['prompts'] ) {
-				$history[] = new Message(
-					MessageRoleEnum::user(),
-					array( new MessagePart( (string) $step['prompts'] ) )
-				);
-			}
-			if ( isset( $step['response'] ) && '' !== $step['response'] ) {
-				$history[] = new Message(
-					MessageRoleEnum::model(),
-					array( new MessagePart( (string) $step['response'] ) )
-				);
-			}
-		}
-
-		$current_prompt = implode( PHP_EOL, $prompts );
-
-		$builder = wp_ai_client_prompt( $current_prompt )
-			->using_provider( $this->get_connector_id() )
-			->using_system_instruction( $this->get_system_instructions() )
-			->using_temperature( 0.7 )
-			->using_max_tokens( 4000 );
-
-		if ( count( $history ) > 0 ) {
-			$builder = $builder->with_history( ...$history );
-		}
-
-		$result = $builder->generate_text();
-
-		if ( is_wp_error( $result ) ) {
-			error_log( '[WP Performance Wizard][ChatGPT] generate_text WP_Error: ' . $result->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			return 'ChatGPT API error: ' . $result->get_error_message();
-		}
-
-		return $result;
+		return $this->send_via_ai_client(
+			$prompts,
+			$current_step,
+			$previous_steps,
+			array(
+				'max_tokens'  => 4000,
+				'temperature' => 0.7,
+			)
+		);
 	}
 }

--- a/includes/class-performance-wizard-ai-agent-chatgpt.php
+++ b/includes/class-performance-wizard-ai-agent-chatgpt.php
@@ -3,13 +3,16 @@
  * Performance Wizard AI Agent for ChatGPT.
  *
  * This file contains the ChatGPT AI agent implementation for the WordPress Performance Wizard.
- * It handles API connections to OpenAI's ChatGPT/GPT service.
- *
- * Credentials are supplied through the WordPress 7.0 Connectors API. Users
- * configure their key from the core Connectors admin screen.
+ * Requests go through the WordPress 7.0 AI Client API (wp_ai_client_prompt) so credentials
+ * resolved by the Connectors API are applied automatically and model selection is delegated
+ * to the registry instead of being hardcoded.
  *
  * @package wp-performance-wizard
  */
+
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 
 /**
  * A class that enables connections to OpenAI ChatGPT.
@@ -29,11 +32,11 @@ class Performance_Wizard_AI_Agent_ChatGPT extends Performance_Wizard_AI_Agent_Ba
 	}
 
 	/**
-	 * Send a single prompt to the ChatGPT API.
+	 * Send a single prompt to ChatGPT via the WordPress AI Client API.
 	 *
-	 * @param string $prompt The prompt to pass to the agent.
-	 * @param int    $current_step The current step in the process.
-	 * @param array  $previous_steps The previous steps in the process.
+	 * @param string $prompt               The prompt to pass to the agent.
+	 * @param int    $current_step         The current step in the process.
+	 * @param array  $previous_steps       The previous steps in the process.
 	 * @param bool   $additional_questions Whether to ask additional questions.
 	 * @return string The response from the API.
 	 */
@@ -45,95 +48,58 @@ class Performance_Wizard_AI_Agent_ChatGPT extends Performance_Wizard_AI_Agent_Ba
 	}
 
 	/**
-	 * Send prompts to the ChatGPT API.
+	 * Send prompts to ChatGPT via the WordPress AI Client API.
 	 *
-	 * @param array $prompts The prompts to pass to the agent.
-	 * @param int   $current_step The current step in the process.
-	 * @param array $previous_steps The previous steps in the process.
+	 * @param array $prompts              The prompts to pass to the agent.
+	 * @param int   $current_step         The current step in the process.
+	 * @param array $previous_steps       The previous steps in the process.
 	 * @param bool  $additional_questions Whether to ask additional questions.
 	 * @return string The response from the API.
 	 */
 	public function send_prompts( array $prompts, int $current_step, array $previous_steps, bool $additional_questions ): string {
-		$api_url            = 'https://api.openai.com/v1/chat/completions';
-		$api_key            = $this->get_api_key();
-		$system_instruction = $this->get_system_instructions();
-
-		$messages = array();
-
-		// Add system instruction as the first message.
-		if ( '' !== $system_instruction ) {
-			$messages[] = array(
-				'role'    => 'system',
-				'content' => $system_instruction,
-			);
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return 'WordPress AI Client API (wp_ai_client_prompt) is unavailable. WordPress 7.0+ is required.';
 		}
 
-		// Add previous conversation history.
-		$max_steps = $current_step;
-		for ( $i = 1; $i < $max_steps; $i++ ) {
+		$history = array();
+		for ( $i = 1; $i < $current_step; $i++ ) {
 			if ( ! isset( $previous_steps[ $i ] ) ) {
 				continue;
 			}
 			$step = $previous_steps[ $i ];
-			if ( isset( $step['prompts'] ) ) {
-				$messages[] = array(
-					'role'    => 'user',
-					'content' => $step['prompts'],
+			if ( isset( $step['prompts'] ) && '' !== $step['prompts'] ) {
+				$history[] = new Message(
+					MessageRoleEnum::user(),
+					array( new MessagePart( (string) $step['prompts'] ) )
 				);
 			}
-			if ( isset( $step['response'] ) ) {
-				$messages[] = array(
-					'role'    => 'assistant',
-					'content' => $step['response'],
+			if ( isset( $step['response'] ) && '' !== $step['response'] ) {
+				$history[] = new Message(
+					MessageRoleEnum::model(),
+					array( new MessagePart( (string) $step['response'] ) )
 				);
 			}
 		}
 
-		// Add current prompts.
-		$messages[] = array(
-			'role'    => 'user',
-			'content' => implode( PHP_EOL, $prompts ),
-		);
+		$current_prompt = implode( PHP_EOL, $prompts );
 
-		$data = array(
-			'model'       => 'gpt-3.5-turbo', // Use the latest free model.
-			'messages'    => $messages,
-			'temperature' => 0.7,
-			'max_tokens'  => 4000,
-		);
+		$builder = wp_ai_client_prompt( $current_prompt )
+			->using_provider( $this->get_connector_id() )
+			->using_system_instruction( $this->get_system_instructions() )
+			->using_temperature( 0.7 )
+			->using_max_tokens( 4000 );
 
-		// Log the size of the data payload for reference.
-		error_log( 'ChatGPT data payload size: ' . strlen( wp_json_encode( $data ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-
-		$response = wp_remote_post(
-			$api_url,
-			array(
-				'body'    => wp_json_encode( $data ),
-				'timeout' => 180, // Allow up to 3 minutes.
-				'headers' => array(
-					'Content-Type'  => 'application/json',
-					'Authorization' => 'Bearer ' . $api_key,
-				),
-			)
-		);
-
-		if ( is_wp_error( $response ) ) {
-			return $response->get_error_message();
+		if ( count( $history ) > 0 ) {
+			$builder = $builder->with_history( ...$history );
 		}
 
-		// Check for errors, then return the response parameters.
-		if ( 200 !== $response['response']['code'] ) {
-			return $response['response']['message'];
+		$result = $builder->generate_text();
+
+		if ( is_wp_error( $result ) ) {
+			error_log( '[WP Performance Wizard][ChatGPT] generate_text WP_Error: ' . $result->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			return 'ChatGPT API error: ' . $result->get_error_message();
 		}
 
-		$response_body = wp_remote_retrieve_body( $response );
-		$response_data = json_decode( $response_body, true );
-
-		// Check if we have a valid response structure.
-		if ( isset( $response_data['choices'][0]['message']['content'] ) ) {
-			return $response_data['choices'][0]['message']['content'];
-		}
-
-		return 'No response from ChatGPT.';
+		return $result;
 	}
 }

--- a/includes/class-performance-wizard-ai-agent-claude.php
+++ b/includes/class-performance-wizard-ai-agent-claude.php
@@ -2,17 +2,13 @@
 /**
  * Performance Wizard AI Agent for Claude.
  *
- * This file contains the Claude AI agent implementation for the WordPress Performance Wizard.
- * Requests go through the WordPress 7.0 AI Client API (wp_ai_client_prompt) so credentials
- * resolved by the Connectors API are applied automatically and model selection is delegated
- * to the registry instead of being hardcoded.
+ * Requests go through the WordPress 7.0 AI Client API via the shared
+ * Performance_Wizard_AI_Agent_Base::send_via_ai_client() helper, which adds an
+ * extended request timeout and exponential-backoff retries for transient
+ * failures. Credentials are resolved by the Connectors API.
  *
  * @package wp-performance-wizard
  */
-
-use WordPress\AiClient\Messages\DTO\Message;
-use WordPress\AiClient\Messages\DTO\MessagePart;
-use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 
 /**
  * A class that enables connections to Anthropic Claude AI.
@@ -32,7 +28,7 @@ class Performance_Wizard_AI_Agent_Claude extends Performance_Wizard_AI_Agent_Bas
 	}
 
 	/**
-	 * Send a single prompt to Claude via the WordPress AI Client API.
+	 * Send a single prompt to Claude.
 	 *
 	 * @param string $prompt               The prompt to pass to the agent.
 	 * @param int    $current_step         The current step in the process.
@@ -48,7 +44,7 @@ class Performance_Wizard_AI_Agent_Claude extends Performance_Wizard_AI_Agent_Bas
 	}
 
 	/**
-	 * Send prompts to Claude via the WordPress AI Client API.
+	 * Send prompts to Claude.
 	 *
 	 * @param array $prompts              The prompts to pass to the agent.
 	 * @param int   $current_step         The current step in the process.
@@ -57,48 +53,6 @@ class Performance_Wizard_AI_Agent_Claude extends Performance_Wizard_AI_Agent_Bas
 	 * @return string The response from the API.
 	 */
 	public function send_prompts( array $prompts, int $current_step, array $previous_steps, bool $additional_questions ): string {
-		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-			return 'WordPress AI Client API (wp_ai_client_prompt) is unavailable. WordPress 7.0+ is required.';
-		}
-
-		$history = array();
-		for ( $i = 1; $i < $current_step; $i++ ) {
-			if ( ! isset( $previous_steps[ $i ] ) ) {
-				continue;
-			}
-			$step = $previous_steps[ $i ];
-			if ( isset( $step['prompts'] ) && '' !== $step['prompts'] ) {
-				$history[] = new Message(
-					MessageRoleEnum::user(),
-					array( new MessagePart( (string) $step['prompts'] ) )
-				);
-			}
-			if ( isset( $step['response'] ) && '' !== $step['response'] ) {
-				$history[] = new Message(
-					MessageRoleEnum::model(),
-					array( new MessagePart( (string) $step['response'] ) )
-				);
-			}
-		}
-
-		$current_prompt = implode( PHP_EOL, $prompts );
-
-		$builder = wp_ai_client_prompt( $current_prompt )
-			->using_provider( $this->get_connector_id() )
-			->using_system_instruction( $this->get_system_instructions() )
-			->using_max_tokens( 2048 );
-
-		if ( count( $history ) > 0 ) {
-			$builder = $builder->with_history( ...$history );
-		}
-
-		$result = $builder->generate_text();
-
-		if ( is_wp_error( $result ) ) {
-			error_log( '[WP Performance Wizard][Claude] generate_text WP_Error: ' . $result->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			return 'Claude API error: ' . $result->get_error_message();
-		}
-
-		return $result;
+		return $this->send_via_ai_client( $prompts, $current_step, $previous_steps );
 	}
 }

--- a/includes/class-performance-wizard-ai-agent-claude.php
+++ b/includes/class-performance-wizard-ai-agent-claude.php
@@ -3,13 +3,16 @@
  * Performance Wizard AI Agent for Claude.
  *
  * This file contains the Claude AI agent implementation for the WordPress Performance Wizard.
- * It handles API connections to Anthropic's Claude AI service.
- *
- * Credentials are supplied through the WordPress 7.0 Connectors API. Users
- * configure their key from the core Connectors admin screen.
+ * Requests go through the WordPress 7.0 AI Client API (wp_ai_client_prompt) so credentials
+ * resolved by the Connectors API are applied automatically and model selection is delegated
+ * to the registry instead of being hardcoded.
  *
  * @package wp-performance-wizard
  */
+
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 
 /**
  * A class that enables connections to Anthropic Claude AI.
@@ -29,11 +32,11 @@ class Performance_Wizard_AI_Agent_Claude extends Performance_Wizard_AI_Agent_Bas
 	}
 
 	/**
-	 * Send a single prompt to the Claude API.
+	 * Send a single prompt to Claude via the WordPress AI Client API.
 	 *
-	 * @param string $prompt The prompt to pass to the agent.
-	 * @param int    $current_step The current step in the process.
-	 * @param array  $previous_steps The previous steps in the process.
+	 * @param string $prompt               The prompt to pass to the agent.
+	 * @param int    $current_step         The current step in the process.
+	 * @param array  $previous_steps       The previous steps in the process.
 	 * @param bool   $additional_questions Whether to ask additional questions.
 	 * @return string The response from the API.
 	 */
@@ -45,75 +48,57 @@ class Performance_Wizard_AI_Agent_Claude extends Performance_Wizard_AI_Agent_Bas
 	}
 
 	/**
-	 * Send prompts to the Claude API.
+	 * Send prompts to Claude via the WordPress AI Client API.
 	 *
-	 * @param array $prompts The prompts to pass to the agent.
-	 * @param int   $current_step The current step in the process.
-	 * @param array $previous_steps The previous steps in the process.
+	 * @param array $prompts              The prompts to pass to the agent.
+	 * @param int   $current_step         The current step in the process.
+	 * @param array $previous_steps       The previous steps in the process.
 	 * @param bool  $additional_questions Whether to ask additional questions.
 	 * @return string The response from the API.
 	 */
 	public function send_prompts( array $prompts, int $current_step, array $previous_steps, bool $additional_questions ): string {
-		$api_url            = 'https://api.anthropic.com/v1/messages';
-		$api_key            = $this->get_api_key();
-		$system_instruction = $this->get_system_instructions();
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return 'WordPress AI Client API (wp_ai_client_prompt) is unavailable. WordPress 7.0+ is required.';
+		}
 
-		$messages  = array();
-		$max_steps = $current_step;
-		for ( $i = 1; $i < $max_steps; $i++ ) {
+		$history = array();
+		for ( $i = 1; $i < $current_step; $i++ ) {
 			if ( ! isset( $previous_steps[ $i ] ) ) {
 				continue;
 			}
 			$step = $previous_steps[ $i ];
-			if ( isset( $step['prompts'] ) ) {
-				$messages[] = array(
-					'role'    => 'user',
-					'content' => $step['prompts'],
+			if ( isset( $step['prompts'] ) && '' !== $step['prompts'] ) {
+				$history[] = new Message(
+					MessageRoleEnum::user(),
+					array( new MessagePart( (string) $step['prompts'] ) )
 				);
 			}
-			if ( isset( $step['response'] ) ) {
-				$messages[] = array(
-					'role'    => 'assistant',
-					'content' => $step['response'],
+			if ( isset( $step['response'] ) && '' !== $step['response'] ) {
+				$history[] = new Message(
+					MessageRoleEnum::model(),
+					array( new MessagePart( (string) $step['response'] ) )
 				);
 			}
 		}
-		$messages[] = array(
-			'role'    => 'user',
-			'content' => implode( PHP_EOL, $prompts ),
-		);
 
-		$data = array(
-			'model'      => 'claude-3-7-sonnet-latest',
-			'system'     => $system_instruction,
-			'messages'   => $messages,
-			'max_tokens' => 2048,
-		);
+		$current_prompt = implode( PHP_EOL, $prompts );
 
-		$response = wp_remote_post(
-			$api_url,
-			array(
-				'body'    => wp_json_encode( $data ),
-				'headers' => array(
-					'Content-Type'      => 'application/json',
-					'X-API-Key'         => $api_key,
-					'Anthropic-Version' => '2023-06-01',
-				),
-				'timeout' => 180,
-			)
-		);
+		$builder = wp_ai_client_prompt( $current_prompt )
+			->using_provider( $this->get_connector_id() )
+			->using_system_instruction( $this->get_system_instructions() )
+			->using_max_tokens( 2048 );
 
-		if ( is_wp_error( $response ) ) {
-			return $response->get_error_message();
+		if ( count( $history ) > 0 ) {
+			$builder = $builder->with_history( ...$history );
 		}
-		if ( 200 !== $response['response']['code'] ) {
-			return $response['response']['message'];
+
+		$result = $builder->generate_text();
+
+		if ( is_wp_error( $result ) ) {
+			error_log( '[WP Performance Wizard][Claude] generate_text WP_Error: ' . $result->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			return 'Claude API error: ' . $result->get_error_message();
 		}
-		$body = wp_remote_retrieve_body( $response );
-		$data = json_decode( $body, true );
-		if ( isset( $data['content'][0]['text'] ) ) {
-			return $data['content'][0]['text'];
-		}
-		return 'No response from Claude.';
+
+		return $result;
 	}
 }

--- a/includes/class-performance-wizard-ai-agent-gemini.php
+++ b/includes/class-performance-wizard-ai-agent-gemini.php
@@ -2,16 +2,13 @@
 /**
  * A class that enables connections to Gemini AI.
  *
- * Requests go through the WordPress 7.0 AI Client API (wp_ai_client_prompt) so credentials
- * resolved by the Connectors API are applied automatically and model selection is delegated
- * to the registry instead of being hardcoded.
+ * Requests go through the WordPress 7.0 AI Client API via the shared
+ * Performance_Wizard_AI_Agent_Base::send_via_ai_client() helper, which adds an
+ * extended request timeout and exponential-backoff retries for transient
+ * failures. Credentials are resolved by the Connectors API.
  *
  * @package wp-performance-wizard
  */
-
-use WordPress\AiClient\Messages\DTO\Message;
-use WordPress\AiClient\Messages\DTO\MessagePart;
-use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 
 /**
  * The Gemini class.
@@ -31,7 +28,7 @@ class Performance_Wizard_AI_Agent_Gemini extends Performance_Wizard_AI_Agent_Bas
 	}
 
 	/**
-	 * Send a single prompt to Gemini via the WordPress AI Client API.
+	 * Send a single prompt to Gemini.
 	 *
 	 * @param string   $prompt               The prompt to pass to the agent.
 	 * @param int      $current_step         The current step in the process.
@@ -48,7 +45,7 @@ class Performance_Wizard_AI_Agent_Gemini extends Performance_Wizard_AI_Agent_Bas
 	}
 
 	/**
-	 * Send prompts to Gemini via the WordPress AI Client API.
+	 * Send prompts to Gemini.
 	 *
 	 * @param array $prompts              The prompts to pass to the agent.
 	 * @param int   $current_step         The current step in the process.
@@ -57,47 +54,6 @@ class Performance_Wizard_AI_Agent_Gemini extends Performance_Wizard_AI_Agent_Bas
 	 * @return string The response from the API.
 	 */
 	public function send_prompts( array $prompts, int $current_step, array $previous_steps, bool $additional_questions ): string {
-		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-			return 'WordPress AI Client API (wp_ai_client_prompt) is unavailable. WordPress 7.0+ is required.';
-		}
-
-		$history = array();
-		for ( $i = 1; $i < $current_step; $i++ ) {
-			if ( ! isset( $previous_steps[ $i ] ) ) {
-				continue;
-			}
-			$step = $previous_steps[ $i ];
-			if ( isset( $step['prompts'] ) && '' !== $step['prompts'] ) {
-				$history[] = new Message(
-					MessageRoleEnum::user(),
-					array( new MessagePart( (string) $step['prompts'] ) )
-				);
-			}
-			if ( isset( $step['response'] ) && '' !== $step['response'] ) {
-				$history[] = new Message(
-					MessageRoleEnum::model(),
-					array( new MessagePart( (string) $step['response'] ) )
-				);
-			}
-		}
-
-		$current_prompt = implode( PHP_EOL, $prompts );
-
-		$builder = wp_ai_client_prompt( $current_prompt )
-			->using_provider( $this->get_connector_id() )
-			->using_system_instruction( $this->get_system_instructions() );
-
-		if ( count( $history ) > 0 ) {
-			$builder = $builder->with_history( ...$history );
-		}
-
-		$result = $builder->generate_text();
-
-		if ( is_wp_error( $result ) ) {
-			error_log( '[WP Performance Wizard][Gemini] generate_text WP_Error: ' . $result->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			return 'Gemini API error: ' . $result->get_error_message();
-		}
-
-		return $result;
+		return $this->send_via_ai_client( $prompts, $current_step, $previous_steps );
 	}
 }

--- a/includes/class-performance-wizard-ai-agent-gemini.php
+++ b/includes/class-performance-wizard-ai-agent-gemini.php
@@ -2,135 +2,21 @@
 /**
  * A class that enables connections to Gemini AI.
  *
- * Credentials are supplied through the WordPress 7.0 Connectors API.
- * Users configure their key from the core Connectors admin screen.
+ * Requests go through the WordPress 7.0 AI Client API (wp_ai_client_prompt) so credentials
+ * resolved by the Connectors API are applied automatically and model selection is delegated
+ * to the registry instead of being hardcoded.
  *
  * @package wp-performance-wizard
  */
+
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 
 /**
  * The Gemini class.
  */
 class Performance_Wizard_AI_Agent_Gemini extends Performance_Wizard_AI_Agent_Base {
-
-	/**
-	 * A method to send a single prompt to the agent.
-	 *
-	 * @param string   $prompt         The prompt to pass to the agent.
-	 * @param int      $current_step   The current step in the process.
-	 * @param string[] $previous_steps The previous steps in the process.
-	 * @param bool     $additional_questions Whether to ask additional questions.
-	 *
-	 * @return string The response from the API.
-	 */
-	public function send_prompt( string $prompt, int $current_step, array $previous_steps, bool $additional_questions ): string {
-		if ( $additional_questions ) {
-			$prompt .= PHP_EOL . $this->get_additional_questions_prompt();
-		}
-
-		return $this->send_prompts( array( $prompt ), $current_step, $previous_steps, $additional_questions );
-	}
-
-	/**
-	 * A method for calling the API of the AI agent.
-	 *
-	 * @param array $prompts        The prompts to pass to the agent.
-	 * @param int   $current_step   The current step in the process.
-	 * @param array $previous_steps The previous steps in the process.
-	 * @param bool  $additional_questions Whether to ask additional questions.
-	 *
-	 * @return string The response from the API.
-	 */
-	public function send_prompts( array $prompts, int $current_step, array $previous_steps, bool $additional_questions ): string {
-
-		// Send a REST API request to the Gemini API, as documented here: https://ai.google.dev/gemini-api/docs/get-started/tutorial?lang=rest.
-		$api_base     = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro-latest:generateContent';
-		$query_params = array(
-			'key' => $this->get_api_key(),
-		);
-
-		$parts = array(
-			'text' => implode( PHP_EOL, $prompts ),
-		);
-
-		$contents  = array();
-		$max_steps = $current_step;
-		for ( $i = 1; $i < $max_steps; $i++ ) {
-			if ( ! isset( $previous_steps[ $i ] ) ) {
-				continue;
-			}
-			$step = $previous_steps[ $i ];
-			if ( isset( $step['prompts'] ) ) {
-				array_push(
-					$contents,
-					array(
-						'parts' => array(
-							'text' => $step['prompts'],
-						),
-						'role'  => 'user',
-					)
-				);
-			}
-			if ( isset( $step['response'] ) ) {
-				array_push(
-					$contents,
-					array(
-						'parts' => array(
-							'text' => $step['response'],
-						),
-						'role'  => 'model',
-					)
-				);
-			}
-		}
-
-		array_push(
-			$contents,
-			array(
-				'parts' => $parts,
-				'role'  => 'user',
-			)
-		);
-
-		$data = array(
-			'system_instruction' => array(
-				'parts' => array(
-					'text' => $this->get_system_instructions(),
-				),
-			),
-			'contents'           => $contents,
-		);
-
-		// Log the size of the data payload for reference.
-		error_log( 'Gemini data payload size: ' . strlen( wp_json_encode( $data ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-
-		$response = wp_remote_post(
-			add_query_arg( $query_params, $api_base ),
-			array(
-				'body'    => wp_json_encode( $data ),
-				'method'  => 'POST',
-				'timeout' => 180, // Allow up to 3 minutes.
-				'headers' => array(
-					'Content-Type' => 'application/json',
-				),
-			)
-		);
-
-		if ( is_wp_error( $response ) ) {
-			return $response->get_error_message();
-		}
-
-		// Check for errors, then return the response parameters.
-		if ( 200 !== $response['response']['code'] ) {
-			return $response['response']['message'];
-		}
-
-		$response_body = wp_remote_retrieve_body( $response );
-		$response_data = json_decode( $response_body, true );
-
-		return $response_data['candidates'][0]['content']['parts'][0]['text'];
-	}
-
 
 	/**
 	 * Construct the agent.
@@ -142,5 +28,76 @@ class Performance_Wizard_AI_Agent_Gemini extends Performance_Wizard_AI_Agent_Bas
 		$this->set_wizard( $wizard );
 		$this->set_description( 'Gemini is a is a generative artificial intelligence chatbot developed by Google.' );
 		$this->set_connector_id( 'gemini' );
+	}
+
+	/**
+	 * Send a single prompt to Gemini via the WordPress AI Client API.
+	 *
+	 * @param string   $prompt               The prompt to pass to the agent.
+	 * @param int      $current_step         The current step in the process.
+	 * @param string[] $previous_steps       The previous steps in the process.
+	 * @param bool     $additional_questions Whether to ask additional questions.
+	 * @return string The response from the API.
+	 */
+	public function send_prompt( string $prompt, int $current_step, array $previous_steps, bool $additional_questions ): string {
+		if ( $additional_questions ) {
+			$prompt .= PHP_EOL . $this->get_additional_questions_prompt();
+		}
+
+		return $this->send_prompts( array( $prompt ), $current_step, $previous_steps, $additional_questions );
+	}
+
+	/**
+	 * Send prompts to Gemini via the WordPress AI Client API.
+	 *
+	 * @param array $prompts              The prompts to pass to the agent.
+	 * @param int   $current_step         The current step in the process.
+	 * @param array $previous_steps       The previous steps in the process.
+	 * @param bool  $additional_questions Whether to ask additional questions.
+	 * @return string The response from the API.
+	 */
+	public function send_prompts( array $prompts, int $current_step, array $previous_steps, bool $additional_questions ): string {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return 'WordPress AI Client API (wp_ai_client_prompt) is unavailable. WordPress 7.0+ is required.';
+		}
+
+		$history = array();
+		for ( $i = 1; $i < $current_step; $i++ ) {
+			if ( ! isset( $previous_steps[ $i ] ) ) {
+				continue;
+			}
+			$step = $previous_steps[ $i ];
+			if ( isset( $step['prompts'] ) && '' !== $step['prompts'] ) {
+				$history[] = new Message(
+					MessageRoleEnum::user(),
+					array( new MessagePart( (string) $step['prompts'] ) )
+				);
+			}
+			if ( isset( $step['response'] ) && '' !== $step['response'] ) {
+				$history[] = new Message(
+					MessageRoleEnum::model(),
+					array( new MessagePart( (string) $step['response'] ) )
+				);
+			}
+		}
+
+		$current_prompt = implode( PHP_EOL, $prompts );
+
+		$builder = wp_ai_client_prompt( $current_prompt )
+			->using_provider( $this->get_connector_id() )
+			->using_system_instruction( $this->get_system_instructions() );
+
+		if ( count( $history ) > 0 ) {
+			$builder = $builder->with_history( ...$history );
+		}
+
+		$result = $builder->generate_text();
+
+		if ( is_wp_error( $result ) ) {
+			error_log( '[WP Performance Wizard][Gemini] generate_text WP_Error: ' . $result->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			return 'Gemini API error: ' . $result->get_error_message();
+		}
+
+		return $result;
 	}
 }

--- a/includes/class-performance-wizard-ai-agent-gemini.php
+++ b/includes/class-performance-wizard-ai-agent-gemini.php
@@ -23,7 +23,7 @@ class Performance_Wizard_AI_Agent_Gemini extends Performance_Wizard_AI_Agent_Bas
 	public function __construct( WP_Performance_Wizard $wizard ) {
 		$this->set_name( 'Gemini' );
 		$this->set_wizard( $wizard );
-		$this->set_description( 'Gemini is a is a generative artificial intelligence chatbot developed by Google.' );
+		$this->set_description( 'Gemini is a generative artificial intelligence chatbot developed by Google.' );
 		$this->set_connector_id( 'gemini' );
 	}
 

--- a/includes/class-performance-wizard-data-source-html.php
+++ b/includes/class-performance-wizard-data-source-html.php
@@ -46,9 +46,22 @@ class Performance_Wizard_Data_Source_HTML extends Performance_Wizard_Data_Source
 				if ( array_key_exists( $url, $cache ) ) {
 					$body = $cache[ $url ];
 				} else {
-					$response = wp_remote_get( $url, array( 'timeout' => 30 ) );
-					if ( ! is_wp_error( $response ) ) {
+					// The plugin fetches the site's own URL, so disabling SSL
+					// verification is safe and necessary for local dev setups
+					// (*.localhost, *.test, *.local) using self-signed certs.
+					$args     = array(
+						'timeout'   => 30,
+						'sslverify' => false,
+					);
+					$response = wp_remote_get( $url, $args );
+					if ( is_wp_error( $response ) ) {
+						error_log( '[WP Performance Wizard][HTML] wp_remote_get failed for ' . $url . ': ' . $response->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					} else {
+						$code = (int) wp_remote_retrieve_response_code( $response );
 						$body = wp_remote_retrieve_body( $response );
+						if ( 200 !== $code || '' === $body ) {
+							error_log( sprintf( '[WP Performance Wizard][HTML] %s returned HTTP %d, body length %d', $url, $code, strlen( $body ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+						}
 					}
 					$cache[ $url ] = $body;
 				}

--- a/includes/class-performance-wizard-data-source-html.php
+++ b/includes/class-performance-wizard-data-source-html.php
@@ -46,14 +46,18 @@ class Performance_Wizard_Data_Source_HTML extends Performance_Wizard_Data_Source
 				if ( array_key_exists( $url, $cache ) ) {
 					$body = $cache[ $url ];
 				} else {
-					// The plugin fetches the site's own URL, so disabling SSL
-					// verification is safe and necessary for local dev setups
-					// (*.localhost, *.test, *.local) using self-signed certs.
-					$args     = array(
+					// Only relax SSL verification on local/development
+					// environments where self-signed certs are common
+					// (*.localhost, *.test, *.local). In production the
+					// plugin fetches the site's own URL, so SSL verification
+					// must remain enabled to prevent MITM tampering of the
+					// markup that is sent to the AI agent.
+					$is_dev_env = in_array( wp_get_environment_type(), array( 'local', 'development' ), true );
+					$args       = array(
 						'timeout'   => 30,
-						'sslverify' => false,
+						'sslverify' => ! $is_dev_env,
 					);
-					$response = wp_remote_get( $url, $args );
+					$response   = wp_remote_get( $url, $args );
 					if ( is_wp_error( $response ) ) {
 						error_log( '[WP Performance Wizard][HTML] wp_remote_get failed for ' . $url . ': ' . $response->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 					} else {

--- a/includes/class-performance-wizard-rest-api.php
+++ b/includes/class-performance-wizard-rest-api.php
@@ -96,7 +96,7 @@ class Performance_Wizard_Rest_API {
 		$response             = '';
 
 		// Set the AI agent based on the selected model if provided.
-		if ( '' !== $model ) {
+		if ( is_string( $model ) && '' !== $model ) {
 			$model_set = $this->wizard->set_ai_agent( $model );
 			if ( ! $model_set ) {
 				return new WP_REST_Response(
@@ -104,6 +104,21 @@ class Performance_Wizard_Rest_API {
 					400
 				);
 			}
+		}
+
+		// Commands that require a configured AI agent. Fail early with a clear
+		// message instead of crashing downstream when no provider is connected.
+		$ai_required = array( '_get_next_action_', '_start_', '_run_action_', '_prompt_' );
+		if ( in_array( $command, $ai_required, true ) && null === $this->wizard->get_ai_agent() ) {
+			/** This filter is documented in includes/class-performance-wizard-admin-page.php */
+			$connectors_url = apply_filters( 'wp_performance_wizard_connectors_screen_url', admin_url( 'admin.php?page=options-connectors' ) );
+			return new WP_REST_Response(
+				array(
+					'error'          => __( 'No AI provider is connected. Configure an AI connector (Anthropic, Google Gemini, or OpenAI) to run an analysis.', 'wp-performance-wizard' ),
+					'connectors_url' => $connectors_url,
+				),
+				503
+			);
 		}
 
 		switch ( $command ) {

--- a/includes/class-performance-wizard-settings-page.php
+++ b/includes/class-performance-wizard-settings-page.php
@@ -242,7 +242,7 @@ class Performance_Wizard_Settings_Page {
 		echo '<legend class="screen-reader-text">' . esc_html__( 'File types to include', 'wp-performance-wizard' ) . '</legend>';
 		foreach ( self::SUPPORTED_LANGUAGES as $language ) {
 			$checked = in_array( $language, $selected_languages, true );
-			echo '<label style="margin-right:1em;"><input type="checkbox" name="plugin_source_languages[]" value="' . esc_attr( $language ) . '"' . checked( $checked, true, false ) . '> ';
+			echo '<label style="display:inline-block;margin-right:1em;"><input type="checkbox" name="plugin_source_languages[]" value="' . esc_attr( $language ) . '"' . checked( $checked, true, false ) . '> ';
 			echo esc_html( strtoupper( $language ) );
 			echo '</label>';
 		}
@@ -258,7 +258,7 @@ class Performance_Wizard_Settings_Page {
 		echo '<legend class="screen-reader-text">' . esc_html__( 'Page types', 'wp-performance-wizard' ) . '</legend>';
 		foreach ( self::SUPPORTED_PAGE_TYPES as $page_type => $label ) {
 			$checked = in_array( $page_type, $selected_page_types, true );
-			echo '<label style="margin-right:1em;"><input type="checkbox" name="page_types[]" value="' . esc_attr( $page_type ) . '"' . checked( $checked, true, false ) . '> ';
+			echo '<label style="display:inline-block;margin-right:1em;"><input type="checkbox" name="page_types[]" value="' . esc_attr( $page_type ) . '"' . checked( $checked, true, false ) . '> ';
 			echo esc_html( $label );
 			echo '</label>';
 		}

--- a/includes/js/wp-performance-wizard.js
+++ b/includes/js/wp-performance-wizard.js
@@ -284,8 +284,8 @@
 				nextStep = await getPerfomanceWizardNextStep( step, selectedModel );
 			} catch ( error ) {
 				const data = error && ( error.data || error );
-				const message = ( data && data.error ) ? data.error : ( error && error.message ) || 'Request failed.';
-				const link = ( data && data.connectors_url ) ? ' <a href="' + data.connectors_url + '">Open Connectors</a>' : '';
+				const message = ( data && data.error ) ? data.error : ( error && error.message ) || __( 'Request failed.', 'wp-performance-wizard' );
+				const link = ( data && data.connectors_url ) ? ' <a href="' + data.connectors_url + '">' + __( 'Open Connectors', 'wp-performance-wizard' ) + '</a>' : '';
 				echoToTerminal( '<r>' + message + '</r>' + link );
 				return;
 			}

--- a/includes/js/wp-performance-wizard.js
+++ b/includes/js/wp-performance-wizard.js
@@ -279,7 +279,16 @@
 		}
 
 		while ( ! complete && step <= maxSteps ) {
-			const nextStep = await getPerfomanceWizardNextStep( step, selectedModel );
+			let nextStep;
+			try {
+				nextStep = await getPerfomanceWizardNextStep( step, selectedModel );
+			} catch ( error ) {
+				const data = error && ( error.data || error );
+				const message = ( data && data.error ) ? data.error : ( error && error.message ) || 'Request failed.';
+				const link = ( data && data.connectors_url ) ? ' <a href="' + data.connectors_url + '">Open Connectors</a>' : '';
+				echoToTerminal( '<r>' + message + '</r>' + link );
+				return;
+			}
 			let results;
 			// If the next step isn't in the checked data sources, skip it.
 			if ( ! dataSources.includes( nextStep.title ) ) {

--- a/includes/js/wp-performance-wizard.js
+++ b/includes/js/wp-performance-wizard.js
@@ -441,26 +441,37 @@
 	/**
 	 * Simulate a streaming text effect while keeping Markdown rendering intact.
 	 *
-	 * The accumulated substring is passed through the same Markdown renderer
-	 * used for non-streamed replies on each tick, so formatting (headings,
-	 * lists, links, code) matches the non-streamed path exactly.
+	 * The animation is capped at ~500ms total regardless of response length, so
+	 * long responses still feel snappy. The accumulated substring is passed
+	 * through the same Markdown renderer used for non-streamed replies on each
+	 * tick, so formatting (headings, lists, links, code) matches the
+	 * non-streamed path exactly.
 	 *
 	 * @param {HTMLElement} element  Target element to render into.
 	 * @param {string}      markdown Raw Markdown source to stream.
-	 * @param {number}      speed    Milliseconds between characters.
+	 * @param {number}      speed    (Unused, kept for backward compatibility.)
 	 */
-	function streamText( element, markdown, speed = 30 ) {
+	function streamText( element, markdown, speed = 0 ) { // eslint-disable-line no-unused-vars
 		return new Promise( ( resolve ) => {
 			const source = String( markdown || '' );
-			const chunk  = 5; // Re-render every N chars to avoid O(n^2) full Markdown parses on long responses.
-			let index    = 0;
-			element.innerHTML = '';
+			if ( source.length === 0 ) {
+				element.innerHTML = '';
+				resolve();
+				return;
+			}
+
+			const totalDurationMs = 500;
+			const tickIntervalMs  = 25;
+			const ticks           = Math.max( 1, Math.round( totalDurationMs / tickIntervalMs ) );
+			const chunkSize       = Math.max( 1, Math.ceil( source.length / ticks ) );
+			let index             = 0;
+			element.innerHTML     = '';
 
 			const typeChar = () => {
 				if ( index < source.length ) {
-					index = Math.min( index + chunk, source.length );
+					index = Math.min( index + chunkSize, source.length );
 					element.innerHTML = marked.marked( source.substring( 0, index ) );
-					setTimeout( typeChar, speed * chunk );
+					setTimeout( typeChar, tickIntervalMs );
 				} else {
 					element.innerHTML = marked.marked( source );
 					resolve();

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,7 @@ parameters:
 		- wp-performance-wizard.php
 	scanFiles:
 		- stubs/wp-connectors.php
+		- stubs/wp-ai-client.php
 	excludePaths:
 		- includes/js/
 		- includes/css/

--- a/stubs/wp-ai-client.php
+++ b/stubs/wp-ai-client.php
@@ -39,6 +39,28 @@ namespace WordPress\AiClient\Messages\DTO {
 	}
 }
 
+namespace WordPress\AiClient\Providers\Http\DTO {
+
+	/**
+	 * Minimal RequestOptions DTO stub.
+	 */
+	class RequestOptions {
+		public const KEY_TIMEOUT         = 'timeout';
+		public const KEY_CONNECT_TIMEOUT = 'connectTimeout';
+		public const KEY_MAX_REDIRECTS   = 'maxRedirects';
+
+		/**
+		 * Build from array.
+		 *
+		 * @param array<string,mixed> $array Options.
+		 * @return self
+		 */
+		public static function fromArray( array $array ): self {
+			return new self();
+		}
+	}
+}
+
 namespace WordPress\AiClient\Messages\Enums {
 
 	/**
@@ -119,6 +141,16 @@ namespace {
 			 * @return self
 			 */
 			public function with_history( ...$messages ): self {
+				return $this;
+			}
+
+			/**
+			 * Request options (timeout, redirects, etc.).
+			 *
+			 * @param mixed $options RequestOptions instance.
+			 * @return self
+			 */
+			public function using_request_options( $options ): self {
 				return $this;
 			}
 

--- a/stubs/wp-ai-client.php
+++ b/stubs/wp-ai-client.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Minimal PHPStan stubs for the WordPress 7.0 AI Client API.
+ *
+ * Not loaded at runtime — this file exists only so static analysis can resolve
+ * the AI Client symbols the plugin depends on. The real implementations ship
+ * with WordPress core.
+ *
+ * @package wp-performance-wizard
+ */
+
+namespace WordPress\AiClient\Messages\DTO {
+
+	/**
+	 * Minimal Message DTO stub.
+	 */
+	class Message {
+		/**
+		 * Constructor.
+		 *
+		 * @param mixed              $role  Message role enum instance.
+		 * @param array<int,mixed>   $parts Message parts.
+		 */
+		public function __construct( $role, array $parts ) {}
+	}
+
+	/**
+	 * Minimal MessagePart DTO stub.
+	 */
+	class MessagePart {
+		/**
+		 * Constructor.
+		 *
+		 * @param mixed $content          Part content (string, File, FunctionCall, FunctionResponse).
+		 * @param mixed $channel          Optional channel enum.
+		 * @param mixed $thoughtSignature Optional thought signature.
+		 */
+		public function __construct( $content, $channel = null, $thoughtSignature = null ) {}
+	}
+}
+
+namespace WordPress\AiClient\Messages\Enums {
+
+	/**
+	 * Minimal MessageRoleEnum stub.
+	 */
+	class MessageRoleEnum {
+		/**
+		 * Returns a USER role instance.
+		 *
+		 * @return self
+		 */
+		public static function user(): self {
+			return new self();
+		}
+
+		/**
+		 * Returns a MODEL role instance.
+		 *
+		 * @return self
+		 */
+		public static function model(): self {
+			return new self();
+		}
+	}
+}
+
+namespace {
+
+	if ( ! class_exists( 'WP_AI_Client_Prompt_Builder' ) ) {
+		/**
+		 * Minimal WP_AI_Client_Prompt_Builder stub.
+		 */
+		class WP_AI_Client_Prompt_Builder {
+			/**
+			 * Provider.
+			 *
+			 * @param string $provider Provider id.
+			 * @return self
+			 */
+			public function using_provider( string $provider ): self {
+				return $this;
+			}
+
+			/**
+			 * System instruction.
+			 *
+			 * @param string $instruction System instruction.
+			 * @return self
+			 */
+			public function using_system_instruction( string $instruction ): self {
+				return $this;
+			}
+
+			/**
+			 * Max tokens.
+			 *
+			 * @param int $max_tokens Max tokens.
+			 * @return self
+			 */
+			public function using_max_tokens( int $max_tokens ): self {
+				return $this;
+			}
+
+			/**
+			 * Temperature.
+			 *
+			 * @param float $temperature Temperature.
+			 * @return self
+			 */
+			public function using_temperature( float $temperature ): self {
+				return $this;
+			}
+
+			/**
+			 * History.
+			 *
+			 * @param mixed ...$messages Conversation history.
+			 * @return self
+			 */
+			public function with_history( ...$messages ): self {
+				return $this;
+			}
+
+			/**
+			 * Generate text.
+			 *
+			 * @return string|\WP_Error
+			 */
+			public function generate_text() {
+				return '';
+			}
+		}
+	}
+
+	if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+		/**
+		 * Creates a new AI prompt builder.
+		 *
+		 * @param mixed $prompt Initial prompt content.
+		 * @return WP_AI_Client_Prompt_Builder
+		 */
+		function wp_ai_client_prompt( $prompt = null ): WP_AI_Client_Prompt_Builder {
+			return new WP_AI_Client_Prompt_Builder();
+		}
+	}
+}


### PR DESCRIPTION
## Summary

A small bundle of admin-side fixes uncovered while running the wizard end-to-end on a local site.

- **Checkbox spacing on the Settings page** — the inline `margin-right` on the File Types and Page Types options was being collapsed in form-table context, so adjacent options rendered flush against the previous label text (`PHP[ ]JS[ ]CSS[ ]HTML`). Switched the labels to `display:inline-block` so the margin reliably separates each option.
- **Graceful handling when no AI provider is configured** — `set_ai_agent()` could be called with a `null` model param and fatal; commands that need an AI agent could then call methods on a null agent and surface raw HTTP status strings like "Not Found" as the AGENT response. The REST handler now rejects a `null` model and short-circuits AI-required commands with a 503 + clear message + `connectors_url`. The wizard JS catches the error and prints it to the terminal with an "Open Connectors" link instead of crashing the loop.
- **AI requests now go through the WordPress 7.0 AI Client API** — Claude, ChatGPT, and Gemini agents previously made direct `wp_remote_post` calls with hardcoded model identifiers. When Anthropic deprecated the pinned `claude-3-7-sonnet-latest` URL the API returned 404 and the literal "Not Found" became the AGENT output. Migrated all three to `wp_ai_client_prompt()` so the Connectors API supplies credentials automatically, model selection is delegated to the registry (no pinned versions), and conversation history is expressed as `Message`/`MessagePart` DTOs with USER/MODEL roles. Added a small `stubs/wp-ai-client.php` for PHPStan and registered it in `phpstan.neon.dist`.
- **HTML data source works against local dev hostnames** — `wp_remote_get` was returning empty for sites at URLs like `https://wpdev.localhost` because the default `sslverify` rejected the self-signed cert; the empty body then surfaced to the AI as "no markup available". The URL is the site's own (resolved via `get_site_url`) so we already trust it; passing `sslverify=false` plus logging non-200/empty responses to the PHP error log so the failure isn't silent.

## Test plan

- [ ] On the Settings page, confirm File Types (PHP / JS / CSS / HTML) and Page Types (Home page / Posts archive / Most recent post) have visible spacing between every checkbox and the next label.
- [ ] With no AI connector configured, start an analysis and confirm the wizard terminal prints the "No AI provider is connected" message with an "Open Connectors" link instead of crashing or printing "Not Found".
- [ ] With a connected Anthropic key, run an analysis end-to-end and confirm the AGENT response is real Claude output (no "Not Found", no fatal in the PHP log).
- [ ] On a local dev site (e.g. `https://wpdev.localhost` with a self-signed cert), confirm the HTML data source step returns markup (not an empty body); confirm no SSL errors in the PHP error log.
- [ ] `composer phpcs` and `composer phpstan` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened error handling for AI agent integration with clearer user-facing messages
  * Added stricter parameter validation in API requests
  * Improved error recovery when AI connectors are unavailable or misconfigured
  * Enhanced SSL certificate handling for local development environments
  * Better error logging for data retrieval failures

* **New Features**
  * Error messages now include direct links to connector configuration when needed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamsilverstein/wp-performance-wizard/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->