### PR TITLE
Add a per-provider model setting to control analysis cost

### DIFF
--- a/includes/class-performance-wizard-ai-agent-base.php
+++ b/includes/class-performance-wizard-ai-agent-base.php
@@ -250,6 +250,11 @@ class Performance_Wizard_AI_Agent_Base {
 		$timeout        = isset( $options['timeout'] ) ? (float) $options['timeout'] : 180.0;
 		$max_attempts   = 3;
 
+		// A site admin can choose a specific (often lower-cost) model per
+		// provider. An empty value means "use the provider default model", which
+		// is the AI Client's behavior when no preference is given.
+		$model = Performance_Wizard_Settings_Page::selected_model( $this->get_connector_id() );
+
 		for ( $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
 			$builder = wp_ai_client_prompt( $current_prompt )
 				->using_provider( $this->get_connector_id() )
@@ -260,6 +265,10 @@ class Performance_Wizard_AI_Agent_Base {
 						array( \WordPress\AiClient\Providers\Http\DTO\RequestOptions::KEY_TIMEOUT => $timeout )
 					)
 				);
+
+			if ( '' !== $model ) {
+				$builder = $builder->using_model_preference( $model );
+			}
 
 			if ( isset( $options['temperature'] ) ) {
 				$builder = $builder->using_temperature( (float) $options['temperature'] );

--- a/includes/class-performance-wizard-settings-page.php
+++ b/includes/class-performance-wizard-settings-page.php
@@ -72,6 +72,7 @@ class Performance_Wizard_Settings_Page {
 			'plugin_source_languages' => array( 'php' ),
 			'use_expert_skills'       => true,
 			'page_types'              => array( 'home' ),
+			'ai_models'               => array(),
 		);
 		if ( ! is_array( $stored ) ) {
 			$stored = array();
@@ -148,6 +149,97 @@ class Performance_Wizard_Settings_Page {
 	}
 
 	/**
+	 * The models that can be selected for each AI provider, keyed by connector ID.
+	 *
+	 * Each provider maps to a label and an ordered list of model choices (model
+	 * ID => human-readable label), cheapest first, with an empty model ID
+	 * meaning "use the provider's default model" (the AI Client's behavior when
+	 * no model preference is given). Model IDs are passed to the AI Client's
+	 * using_model_preference(), which falls back to a compatible model when the
+	 * exact ID is unavailable, so a slightly outdated ID degrades gracefully.
+	 *
+	 * Filterable via `wp_performance_wizard_models` so the list can be kept
+	 * current or extended without a plugin update.
+	 *
+	 * @return array<string,mixed> Map keyed by connector ID; each value is an
+	 *                             array with 'label' and 'models' (model ID => label).
+	 */
+	public static function get_supported_models(): array {
+		$models = array(
+			'anthropic' => array(
+				'label'  => __( 'Anthropic Claude', 'wp-performance-wizard' ),
+				'models' => array(
+					''                  => __( 'Provider default', 'wp-performance-wizard' ),
+					'claude-haiku-4-5'  => __( 'Claude Haiku (lowest cost)', 'wp-performance-wizard' ),
+					'claude-sonnet-4-6' => __( 'Claude Sonnet (balanced cost and quality)', 'wp-performance-wizard' ),
+					'claude-opus-4-8'   => __( 'Claude Opus (highest quality, highest cost)', 'wp-performance-wizard' ),
+				),
+			),
+			'gemini'    => array(
+				'label'  => __( 'Google Gemini', 'wp-performance-wizard' ),
+				'models' => array(
+					''                 => __( 'Provider default', 'wp-performance-wizard' ),
+					'gemini-2.5-flash' => __( 'Gemini Flash (lowest cost)', 'wp-performance-wizard' ),
+					'gemini-2.5-pro'   => __( 'Gemini Pro (higher cost)', 'wp-performance-wizard' ),
+				),
+			),
+			'openai'    => array(
+				'label'  => __( 'OpenAI ChatGPT', 'wp-performance-wizard' ),
+				'models' => array(
+					''           => __( 'Provider default', 'wp-performance-wizard' ),
+					'gpt-5-mini' => __( 'GPT-5 mini (lower cost)', 'wp-performance-wizard' ),
+					'gpt-5'      => __( 'GPT-5 (higher cost)', 'wp-performance-wizard' ),
+				),
+			),
+		);
+
+		/**
+		 * Filters the selectable models for each AI provider connector.
+		 *
+		 * @param mixed $models Map keyed by connector ID; each value is an array
+		 *                      with 'label' and 'models' (model ID => label).
+		 */
+		$models = apply_filters( 'wp_performance_wizard_models', $models );
+		return is_array( $models ) ? $models : array();
+	}
+
+	/**
+	 * The model ID selected for a given provider connector.
+	 *
+	 * Returns an empty string (meaning "use the provider default model") when
+	 * nothing is selected or the stored value is not a recognized choice for
+	 * that connector.
+	 *
+	 * Filterable via `wp_performance_wizard_selected_model` so the model can be
+	 * forced in code (for example, from a constant) per connector.
+	 *
+	 * @param string $connector_id The provider connector ID (e.g. 'anthropic').
+	 *
+	 * @return string The selected model ID, or an empty string for the default.
+	 */
+	public static function selected_model( string $connector_id ): string {
+		$options   = self::get_options();
+		$selected  = isset( $options['ai_models'] ) && is_array( $options['ai_models'] ) ? $options['ai_models'] : array();
+		$model     = isset( $selected[ $connector_id ] ) ? (string) $selected[ $connector_id ] : '';
+		$supported = self::get_supported_models();
+
+		// Only honor a stored value that is a recognized choice for the connector.
+		if ( '' !== $model
+			&& ( ! isset( $supported[ $connector_id ]['models'][ $model ] ) ) ) {
+			$model = '';
+		}
+
+		/**
+		 * Filters the model ID used for a given provider connector.
+		 *
+		 * @param mixed  $model        The selected model ID, or an empty string for the provider default.
+		 * @param string $connector_id The provider connector ID.
+		 */
+		$model = apply_filters( 'wp_performance_wizard_selected_model', $model, $connector_id );
+		return is_string( $model ) ? $model : '';
+	}
+
+	/**
 	 * Resolve the URL to fetch for a given page type slug.
 	 *
 	 * Returns an empty string when a representative URL cannot be resolved
@@ -207,6 +299,7 @@ class Performance_Wizard_Settings_Page {
 		$selected_languages  = (array) $options['plugin_source_languages'];
 		$skills_enabled      = (bool) $options['use_expert_skills'];
 		$selected_page_types = (array) $options['page_types'];
+		$selected_models     = isset( $options['ai_models'] ) && is_array( $options['ai_models'] ) ? $options['ai_models'] : array();
 
 		$notice = isset( $_GET['info'] ) ? sanitize_key( wp_unslash( $_GET['info'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
@@ -264,6 +357,30 @@ class Performance_Wizard_Settings_Page {
 		}
 		echo '<p class="description">' . esc_html__( 'Home page is selected by default. Archive and Most recent post may not resolve to a URL on a brand-new site with no published posts.', 'wp-performance-wizard' ) . '</p>';
 		echo '</fieldset></td></tr>';
+		echo '</tbody></table>';
+
+		echo '<h2>' . esc_html__( 'Model Selection', 'wp-performance-wizard' ) . '</h2>';
+		echo '<p>' . esc_html__( 'Choose which model each AI provider uses for the analysis. Lower-cost models (such as Claude Haiku or Gemini Flash) can reduce the cost of a run substantially. "Provider default" leaves the choice to the AI Client. The selection only applies to whichever provider you run the analysis with.', 'wp-performance-wizard' ) . '</p>';
+		echo '<table class="form-table" role="presentation"><tbody>';
+		foreach ( self::get_supported_models() as $connector_id => $provider ) {
+			if ( ! isset( $provider['models'] ) || ! is_array( $provider['models'] ) ) {
+				continue;
+			}
+			$field_id = 'wp-perf-wizard-model-' . sanitize_key( $connector_id );
+			$current  = isset( $selected_models[ $connector_id ] ) ? (string) $selected_models[ $connector_id ] : '';
+			$label    = isset( $provider['label'] ) ? (string) $provider['label'] : $connector_id;
+
+			echo '<tr><th scope="row"><label for="' . esc_attr( $field_id ) . '">' . esc_html( $label ) . '</label></th><td>';
+			echo '<select id="' . esc_attr( $field_id ) . '" name="ai_models[' . esc_attr( $connector_id ) . ']">';
+			foreach ( $provider['models'] as $model_id => $model_label ) {
+				$model_id    = (string) $model_id;
+				$model_label = (string) $model_label;
+				echo '<option value="' . esc_attr( $model_id ) . '"' . selected( $current, $model_id, false ) . '>' . esc_html( $model_label ) . '</option>';
+			}
+			echo '</select>';
+			echo '</td></tr>';
+		}
+		echo '<tr><td colspan="2"><p class="description">' . esc_html__( 'Model IDs can be kept current or extended in code via the wp_performance_wizard_models filter. Unavailable models fall back to a compatible one automatically.', 'wp-performance-wizard' ) . '</p></td></tr>';
 		echo '</tbody></table>';
 
 		echo '<h2>' . esc_html__( 'Expert Reference Skills', 'wp-performance-wizard' ) . '</h2>';
@@ -335,11 +452,30 @@ class Performance_Wizard_Settings_Page {
 			$submitted_page_types = array( 'home' );
 		}
 
+		// Accept a model selection per provider, but only when the submitted
+		// value is a recognized choice for that connector. An empty value means
+		// "use the provider default" and is stored as such.
+		$supported_models = self::get_supported_models();
+		$submitted_models = array();
+		if ( isset( $_POST['ai_models'] ) && is_array( $_POST['ai_models'] ) ) {
+			foreach ( wp_unslash( $_POST['ai_models'] ) as $connector_id => $model_id ) {
+				$connector_id = sanitize_key( (string) $connector_id );
+				$model_id     = sanitize_text_field( (string) $model_id );
+				if ( ! isset( $supported_models[ $connector_id ]['models'] ) ) {
+					continue;
+				}
+				if ( '' === $model_id || isset( $supported_models[ $connector_id ]['models'][ $model_id ] ) ) {
+					$submitted_models[ $connector_id ] = $model_id;
+				}
+			}
+		}
+
 		$options                            = self::get_options();
 		$options['collect_plugin_sources']  = $collect;
 		$options['plugin_source_languages'] = array_values( array_unique( $submitted_languages ) );
 		$options['use_expert_skills']       = $skills_enabled;
 		$options['page_types']              = array_values( array_unique( $submitted_page_types ) );
+		$options['ai_models']               = $submitted_models;
 
 		update_option( self::OPTION_NAME, $options );
 

--- a/includes/class-performance-wizard-settings-page.php
+++ b/includes/class-performance-wizard-settings-page.php
@@ -454,9 +454,13 @@ class Performance_Wizard_Settings_Page {
 
 		// Accept a model selection per provider, but only when the submitted
 		// value is a recognized choice for that connector. An empty value means
-		// "use the provider default" and is stored as such.
+		// "use the provider default" and is stored as such. Seed from the
+		// existing saved selections so a provider that is filtered out of
+		// get_supported_models() (and therefore not rendered or submitted) keeps
+		// its stored selection instead of being silently dropped.
 		$supported_models = self::get_supported_models();
-		$submitted_models = array();
+		$current_options  = self::get_options();
+		$submitted_models = isset( $current_options['ai_models'] ) && is_array( $current_options['ai_models'] ) ? $current_options['ai_models'] : array();
 		if ( isset( $_POST['ai_models'] ) && is_array( $_POST['ai_models'] ) ) {
 			foreach ( wp_unslash( $_POST['ai_models'] ) as $connector_id => $model_id ) {
 				$connector_id = sanitize_key( (string) $connector_id );

--- a/stubs/wp-ai-client.php
+++ b/stubs/wp-ai-client.php
@@ -125,6 +125,17 @@ namespace {
 			}
 
 			/**
+			 * Model preference (ordered list of model IDs; falls back to a
+			 * compatible model when none of them are available).
+			 *
+			 * @param string ...$model_ids Preferred model IDs.
+			 * @return self
+			 */
+			public function using_model_preference( string ...$model_ids ): self {
+				return $this;
+			}
+
+			/**
 			 * Temperature.
 			 *
 			 * @param float $temperature Temperature.


### PR DESCRIPTION
## What

Add a per-provider **Model Selection** setting so users can run the analysis with a lower-cost model instead of always using each provider's default.

Closes #78. Part of #76.

## Why

The plugin sent prompts with `wp_ai_client_prompt( … )->using_provider( $connector_id )` but never specified a model, so WordPress 7.0's AI Client used each provider's **default** model — with no way to opt into a cheaper tier. Lower-cost models (Claude Haiku, Gemini Flash, GPT mini) can cut the cost of a run substantially, which is the most direct response to the ">$7 per run" report in #76.

## How

- New **Model Selection** section on the settings page with a dropdown per provider. Each offers a curated, cost-tiered list (cheapest first) plus a **"Provider default"** no-op option (the current behavior). Selections are stored per connector ID in the plugin options and validated on save.
- `Performance_Wizard_Settings_Page::selected_model( $connector_id )` resolves the choice (ignoring unrecognized values), and `send_via_ai_client()` passes it via `->using_model_preference( $model )` when set. The AI Client falls back to a compatible model when the exact ID is unavailable, so a slightly outdated ID degrades gracefully rather than breaking a run.
- Filters: `wp_performance_wizard_models` (keep the model list current / extend it without a plugin update) and `wp_performance_wizard_selected_model` (force a model in code per connector).
- Added `using_model_preference()` to the AI Client PHPStan stub.

## Notes

Model IDs are best-effort current values; the `wp_performance_wizard_models` filter exists precisely so site owners can correct or extend them. The graceful-fallback behavior of `using_model_preference()` means an unavailable ID is not fatal.

## Testing

- `composer lint` — clean.
- `composer phpstan` — no errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Model Selection” settings section to let admins choose preferred AI model IDs per provider connector.
* **Bug Fixes**
  * Preferences are validated per provider; only recognized models are saved and applied, with provider defaults used when no preference is set.
* **Chores**
  * Updated AI client prompt builder typings to support applying a model preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->