### PR TITLE
Document cost-management levers for analyzer runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ Credentials can also be supplied via environment variable or PHP constant using 
 
 After installing and activating the plugin and connecting at least one AI provider, navigate to **Performance Wizard** in your WordPress admin dashboard. Choose the data sources to include, pick a configured AI model if more than one is available, and run the analysis. Results and recommendations are rendered inline.
 
+## Managing cost
+
+Each analysis step sends data to your chosen AI provider, so a run consumes tokens and incurs provider cost. Several settings let you control that cost, all under **Performance Wizard → Settings** unless noted:
+
+* **Choose a lower-cost model** (*Model Selection*). Each provider offers cheaper tiers - for example Claude Haiku, Gemini Flash, or a GPT mini model - that can reduce the cost of a run substantially compared with the provider's default. "Provider default" leaves the choice to the AI Client.
+* **Analyze fewer page types** (*Page Types to Analyze*). Each selected page type (home page, posts archive, most recent post) adds a full Lighthouse and HTML pass, so analyzing only the home page is the cheapest option.
+* **Leave plugin source collection off** (*Plugin Source Collection*). Including plugin source code can dramatically increase prompt size; keep it disabled unless you specifically need source-level analysis.
+* **Toggle expert reference skills** (*Expert Reference Skills*). The bundled reference material adds context tokens to every step. Disable it to trade some grounding for lower cost.
+
+The plugin also compacts conversation history automatically: the large raw data payloads (Lighthouse JSON, page HTML, and so on) are sent once, for the step that analyzes them, and are not re-sent on later steps - so cost grows roughly linearly with the number of steps rather than quadratically.
+
+For the lowest-cost run: select a low-cost model, analyze only the home page, leave plugin source collection off, and optionally disable expert reference skills.
+
 ## Development
 
 ### Code Quality

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,17 @@ This plugin sends data about your site (HTML, script attribution, theme/plugin m
 
 You need an API key for at least one of the supported providers (Google Gemini, OpenAI, or Anthropic Claude). Pricing depends on the provider and the number of analyses you run.
 
+= How can I reduce the cost of an analysis run? =
+
+A few settings under **Performance Wizard → Settings** control how many tokens a run uses:
+
+* Pick a lower-cost model under **Model Selection** (for example Claude Haiku, Gemini Flash, or a GPT mini model).
+* Analyze fewer page types - each page type adds a full Lighthouse and HTML pass, so analyzing only the home page is cheapest.
+* Leave **Plugin Source Collection** off; including plugin source code greatly increases prompt size.
+* Optionally disable **Expert Reference Skills** to drop the bundled reference tokens added to each step.
+
+The plugin also compacts conversation history automatically, so the large raw data payloads are sent only once rather than re-sent on every later step.
+
 = Where are my API keys stored? =
 
 This plugin does not store API keys. Credentials live in the core Connectors API and can be supplied via the wp-admin Connectors screen, environment variables, or PHP constants.


### PR DESCRIPTION
## What

Document how analyzer actions affect token usage and cost, with concrete tips for minimizing it.

Closes #79. Part of #76.

## Changes

- **README.md** — a new "Managing cost" section covering: choosing a lower-cost model, analyzing fewer page types, leaving plugin source collection off, toggling the expert reference skills, and a note that conversation history is compacted automatically. Ends with a "lowest-cost run" recipe.
- **readme.txt** — a matching FAQ entry: "How can I reduce the cost of an analysis run?"

## Notes

This documents behavior delivered by the sibling PRs, so it reads best merged **after** #77 (history compaction) and #78 (model selection). Docs only — no code changes.

## Testing

- No PHP changed; `composer lint` / `composer phpstan` unaffected (pre-commit hook ran clean).
