### PR TITLE
Add PageSpeed Insights API key to fix Lighthouse quota errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ We welcome contributions! Please follow these steps:
 
 ## Analysis
 The performance wizard will analyze the following data sources to make its recommendations:
-* **PageSpeed Insights API / Lighthouse:** This uses the PageSpeed Insights API to run Lighthouse audits against the site's front end.  Lighthouse provides a comprehensive performance analysis, including metrics like First Contentful Paint, Largest Contentful Paint, and Cumulative Layout Shift.
+* **PageSpeed Insights API / Lighthouse:** This uses the PageSpeed Insights API to run Lighthouse audits against the site's front end.  Lighthouse provides a comprehensive performance analysis, including metrics like First Contentful Paint, Largest Contentful Paint, and Cumulative Layout Shift. Anonymous requests share a near-zero quota and fail with an HTTP 429 error, so add a free [PageSpeed Insights API key](https://developers.google.com/speed/docs/insights/v5/get-started) under **Performance Wizard → Settings** (or via the `wp_performance_wizard_pagespeed_api_key` filter) to get the standard 25,000 requests/day allowance.
 * **Site HTML:** This analyzes the source code of front-end page loads for the home page, a single post, and an archive page, looking for potential performance bottlenecks in the HTML structure itself, such as excessive DOM size or render-blocking resources.
 * **Script Attribution:** This identifies all scripts loaded on the site and attributes them to their source (plugin, theme, or core). This helps pinpoint scripts that might be contributing to slow page load times.
 * **Plugins / Theme:** This gathers information about active plugins and the active theme, including metadata. This data can help identify potential performance issues related to specific plugins or themes.

--- a/includes/class-performance-wizard-data-source-lighthouse.php
+++ b/includes/class-performance-wizard-data-source-lighthouse.php
@@ -84,6 +84,14 @@ class Performance_Wizard_Data_Source_Lighthouse extends Performance_Wizard_Data_
 			'category' => 'performance',
 		);
 
+		// Authenticate the request when a key is configured. Anonymous requests
+		// share a near-zero global quota and fail with an HTTP 429
+		// "rateLimitExceeded" error; a key grants the free per-project quota.
+		$api_key = Performance_Wizard_Settings_Page::pagespeed_api_key();
+		if ( '' !== $api_key ) {
+			$query_params['key'] = $api_key;
+		}
+
 		$response = wp_remote_get(
 			add_query_arg( $query_params, $api_base ),
 			array(
@@ -93,6 +101,14 @@ class Performance_Wizard_Data_Source_Lighthouse extends Performance_Wizard_Data_
 
 		if ( is_wp_error( $response ) ) {
 			return array( 'error' => $response->get_error_message() );
+		}
+
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+		if ( 429 === $response_code ) {
+			$message = '' === $api_key
+				? 'The PageSpeed Insights API returned an HTTP 429 quota error. Anonymous (unauthenticated) requests share a near-zero daily quota. Add a free PageSpeed Insights API key under Performance Wizard > Settings to get the standard 25,000 requests/day allowance.'
+				: 'The PageSpeed Insights API returned an HTTP 429 quota error for the configured API key. The key has exhausted its daily quota, or the PageSpeed Insights API is not enabled for its Google Cloud project. Verify the key in the Google Cloud console and try again later.';
+			return array( 'error' => $message );
 		}
 
 		$body = wp_remote_retrieve_body( $response );

--- a/includes/class-performance-wizard-data-source-lighthouse.php
+++ b/includes/class-performance-wizard-data-source-lighthouse.php
@@ -106,9 +106,22 @@ class Performance_Wizard_Data_Source_Lighthouse extends Performance_Wizard_Data_
 		$response_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( 429 === $response_code ) {
 			$message = '' === $api_key
-				? 'The PageSpeed Insights API returned an HTTP 429 quota error. Anonymous (unauthenticated) requests share a near-zero daily quota. Add a free PageSpeed Insights API key under Performance Wizard > Settings to get the standard 25,000 requests/day allowance.'
-				: 'The PageSpeed Insights API returned an HTTP 429 quota error for the configured API key. The key has exhausted its daily quota, or the PageSpeed Insights API is not enabled for its Google Cloud project. Verify the key in the Google Cloud console and try again later.';
+				? __( 'The PageSpeed Insights API returned an HTTP 429 quota error. Anonymous (unauthenticated) requests share a near-zero daily quota. Add a free PageSpeed Insights API key under Performance Wizard > Settings to get the standard 25,000 requests/day allowance.', 'wp-performance-wizard' )
+				: __( 'The PageSpeed Insights API returned an HTTP 429 quota error for the configured API key. The key has exhausted its daily quota, or the PageSpeed Insights API is not enabled for its Google Cloud project. Verify the key in the Google Cloud console and try again later.', 'wp-performance-wizard' );
 			return array( 'error' => $message );
+		}
+
+		// Normalize any other non-2xx response into an error so a failed request
+		// is not mistaken for a valid result object once JSON-decoded below.
+		if ( $response_code < 200 || $response_code >= 300 ) {
+			return array(
+				'error' => sprintf(
+					/* translators: 1: HTTP status code, 2: requested URL. */
+					__( 'The PageSpeed Insights API request for %2$s failed with HTTP %1$d.', 'wp-performance-wizard' ),
+					$response_code,
+					$url
+				),
+			);
 		}
 
 		$body = wp_remote_retrieve_body( $response );

--- a/includes/class-performance-wizard-settings-page.php
+++ b/includes/class-performance-wizard-settings-page.php
@@ -168,9 +168,10 @@ class Performance_Wizard_Settings_Page {
 		/**
 		 * Filters the PageSpeed Insights API key used for Lighthouse requests.
 		 *
-		 * @param string $key The API key from settings, or an empty string.
+		 * @param mixed $key The API key from settings, or an empty string. Cast to
+		 *                   a string before use, so any value type is tolerated.
 		 */
-		$key = apply_filters( 'wp_performance_wizard_pagespeed_api_key', $key );
+		$key = (string) apply_filters( 'wp_performance_wizard_pagespeed_api_key', $key );
 		return trim( $key );
 	}
 
@@ -297,8 +298,17 @@ class Performance_Wizard_Settings_Page {
 		echo '<h2>' . esc_html__( 'PageSpeed Insights API Key', 'wp-performance-wizard' ) . '</h2>';
 		echo '<p>';
 		printf(
-			/* translators: 1: link to the Google PageSpeed Insights API key page. */
-			esc_html__( 'The Lighthouse data source fetches results from the Google PageSpeed Insights API. Without an API key, requests are anonymous and share a near-zero quota, so they fail with a "Queries per day" quota error even on the first run. Provide a free key from %1$s (the project must have the PageSpeed Insights API enabled) to get the free 25,000 requests/day allowance.', 'wp-performance-wizard' ),
+			wp_kses(
+				/* translators: 1: link to the Google PageSpeed Insights API key page. */
+				__( 'The Lighthouse data source fetches results from the Google PageSpeed Insights API. Without an API key, requests are anonymous and share a near-zero quota, so they fail with a "Queries per day" quota error even on the first run. Provide a free key from %1$s (the project must have the PageSpeed Insights API enabled) to get the free 25,000 requests/day allowance.', 'wp-performance-wizard' ),
+				array(
+					'a' => array(
+						'href'   => array(),
+						'target' => array(),
+						'rel'    => array(),
+					),
+				)
+			),
 			'<a href="https://developers.google.com/speed/docs/insights/v5/get-started" target="_blank" rel="noreferrer noopener">developers.google.com</a>'
 		);
 		echo '</p>';

--- a/includes/class-performance-wizard-settings-page.php
+++ b/includes/class-performance-wizard-settings-page.php
@@ -72,6 +72,7 @@ class Performance_Wizard_Settings_Page {
 			'plugin_source_languages' => array( 'php' ),
 			'use_expert_skills'       => true,
 			'page_types'              => array( 'home' ),
+			'pagespeed_api_key'       => '',
 		);
 		if ( ! is_array( $stored ) ) {
 			$stored = array();
@@ -148,6 +149,32 @@ class Performance_Wizard_Settings_Page {
 	}
 
 	/**
+	 * The Google PageSpeed Insights API key used for Lighthouse requests.
+	 *
+	 * Without a key, requests are anonymous and share a near-zero global
+	 * quota, so they fail with an HTTP 429 "rateLimitExceeded" error. A key
+	 * tied to a Google Cloud project with the PageSpeed Insights API enabled
+	 * grants the free 25,000 requests/day quota.
+	 *
+	 * Filterable via `wp_performance_wizard_pagespeed_api_key` so the key can
+	 * be supplied in code (for example, from an environment variable or
+	 * constant) instead of being stored in the database.
+	 *
+	 * @return string The API key, or an empty string when none is configured.
+	 */
+	public static function pagespeed_api_key(): string {
+		$options = self::get_options();
+		$key     = isset( $options['pagespeed_api_key'] ) ? (string) $options['pagespeed_api_key'] : '';
+		/**
+		 * Filters the PageSpeed Insights API key used for Lighthouse requests.
+		 *
+		 * @param string $key The API key from settings, or an empty string.
+		 */
+		$key = apply_filters( 'wp_performance_wizard_pagespeed_api_key', $key );
+		return trim( $key );
+	}
+
+	/**
 	 * Resolve the URL to fetch for a given page type slug.
 	 *
 	 * Returns an empty string when a representative URL cannot be resolved
@@ -207,6 +234,7 @@ class Performance_Wizard_Settings_Page {
 		$selected_languages  = (array) $options['plugin_source_languages'];
 		$skills_enabled      = (bool) $options['use_expert_skills'];
 		$selected_page_types = (array) $options['page_types'];
+		$pagespeed_api_key   = isset( $options['pagespeed_api_key'] ) ? (string) $options['pagespeed_api_key'] : '';
 
 		$notice = isset( $_GET['info'] ) ? sanitize_key( wp_unslash( $_GET['info'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
@@ -264,6 +292,21 @@ class Performance_Wizard_Settings_Page {
 		}
 		echo '<p class="description">' . esc_html__( 'Home page is selected by default. Archive and Most recent post may not resolve to a URL on a brand-new site with no published posts.', 'wp-performance-wizard' ) . '</p>';
 		echo '</fieldset></td></tr>';
+		echo '</tbody></table>';
+
+		echo '<h2>' . esc_html__( 'PageSpeed Insights API Key', 'wp-performance-wizard' ) . '</h2>';
+		echo '<p>';
+		printf(
+			/* translators: 1: link to the Google PageSpeed Insights API key page. */
+			esc_html__( 'The Lighthouse data source fetches results from the Google PageSpeed Insights API. Without an API key, requests are anonymous and share a near-zero quota, so they fail with a "Queries per day" quota error even on the first run. Provide a free key from %1$s (the project must have the PageSpeed Insights API enabled) to get the free 25,000 requests/day allowance.', 'wp-performance-wizard' ),
+			'<a href="https://developers.google.com/speed/docs/insights/v5/get-started" target="_blank" rel="noreferrer noopener">developers.google.com</a>'
+		);
+		echo '</p>';
+		echo '<table class="form-table" role="presentation"><tbody>';
+		echo '<tr><th scope="row"><label for="wp-perf-wizard-pagespeed-api-key">' . esc_html__( 'API key', 'wp-performance-wizard' ) . '</label></th><td>';
+		echo '<input type="password" autocomplete="off" id="wp-perf-wizard-pagespeed-api-key" name="pagespeed_api_key" class="regular-text" value="' . esc_attr( $pagespeed_api_key ) . '">';
+		echo '<p class="description">' . esc_html__( 'Stored in the site database. Leave blank to make anonymous (unauthenticated) requests, which are heavily rate limited. Can also be set in code via the wp_performance_wizard_pagespeed_api_key filter.', 'wp-performance-wizard' ) . '</p>';
+		echo '</td></tr>';
 		echo '</tbody></table>';
 
 		echo '<h2>' . esc_html__( 'Expert Reference Skills', 'wp-performance-wizard' ) . '</h2>';
@@ -335,11 +378,17 @@ class Performance_Wizard_Settings_Page {
 			$submitted_page_types = array( 'home' );
 		}
 
+		$pagespeed_api_key = '';
+		if ( isset( $_POST['pagespeed_api_key'] ) ) {
+			$pagespeed_api_key = trim( sanitize_text_field( wp_unslash( $_POST['pagespeed_api_key'] ) ) );
+		}
+
 		$options                            = self::get_options();
 		$options['collect_plugin_sources']  = $collect;
 		$options['plugin_source_languages'] = array_values( array_unique( $submitted_languages ) );
 		$options['use_expert_skills']       = $skills_enabled;
 		$options['page_types']              = array_values( array_unique( $submitted_page_types ) );
+		$options['pagespeed_api_key']       = $pagespeed_api_key;
 
 		update_option( self::OPTION_NAME, $options );
 

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,10 @@ You need an API key for at least one of the supported providers (Google Gemini, 
 
 This plugin does not store API keys. Credentials live in the core Connectors API and can be supplied via the wp-admin Connectors screen, environment variables, or PHP constants.
 
+= The Lighthouse step fails with a "Queries per day" / HTTP 429 quota error. How do I fix it? =
+
+The Lighthouse data source uses the Google PageSpeed Insights API. Without an API key, requests are anonymous and share a near-zero global quota, so they can fail with an HTTP 429 "rateLimitExceeded" error even on the first run. Get a free PageSpeed Insights API key (see https://developers.google.com/speed/docs/insights/v5/get-started), make sure the PageSpeed Insights API is enabled for its Google Cloud project, then add it under **Performance Wizard > Settings > PageSpeed Insights API Key**. A key grants the standard 25,000 requests/day allowance. The key can also be supplied in code via the `wp_performance_wizard_pagespeed_api_key` filter.
+
 = What WordPress version do I need? =
 
 WordPress 7.0 or later. This plugin depends on the core Connectors API, which ships in WordPress 7.0.
@@ -81,6 +85,7 @@ No. The plugin only analyzes and recommends. Any changes are up to you.
 == Changelog ==
 
 = 2.0.0 =
+* Added a PageSpeed Insights API key setting to avoid anonymous-request quota (HTTP 429) errors on the Lighthouse data source.
 * Require WordPress 7.0.
 * Removed built-in API key UI - credentials are now supplied via the core Connectors API.
 * Migrated all AI agents to the WordPress 7.0 AI Client API.


### PR DESCRIPTION
## Problem

Running an analysis against a live site fails the Lighthouse step with an HTTP 429 quota error from the PageSpeed Insights API:

> Quota exceeded for quota metric 'Queries' and limit 'Queries per day' ... `quota_limit_value: "0"` against `defaultPerDayPerProject`

This happens even on the very first run, which is surprising — PageSpeed Insights is supposed to offer a free daily allowance.

## Root cause

`fetch_lighthouse_for_url()` called `pagespeedonline/v5/runPagespeed` with **no API key**:

```php
$query_params = array( 'url' => $url, 'category' => 'performance' );
```

Without a key, requests are anonymous and attributed to a shared/default consumer project whose `defaultPerDayPerProject` quota is `0`. That shared pool is effectively always exhausted, so requests 429 immediately. The free **25,000 requests/day** allowance is only granted to authenticated requests carrying a key from a Google Cloud project that has the PageSpeed Insights API enabled.

## Fix

- Add a **PageSpeed Insights API Key** setting (stored in the plugin options array) with a `wp_performance_wizard_pagespeed_api_key` filter so the key can be supplied in code/env instead of the database.
- Send the key as the `key` query parameter when configured.
- On HTTP 429, return an actionable error message instead of forwarding Google's raw quota error to the AI. The message differs depending on whether a key is set (add a key vs. key exhausted / API not enabled for the project).
- Document the requirement and remediation in `readme.txt` (FAQ + changelog) and `README.md`.

## How to use

1. Get a free key: https://developers.google.com/speed/docs/insights/v5/get-started
2. Enable the PageSpeed Insights API for that key's Google Cloud project.
3. Add it under **Performance Wizard → Settings → PageSpeed Insights API Key**.

## Verification

- `composer lint` (PHPCS) — clean
- `composer phpstan` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PageSpeed Insights API key configuration in Performance Wizard Settings to increase API usage allowance.
  * Enhanced error messaging to clarify quota-related failures.

* **Documentation**
  * Updated README and FAQ with instructions on obtaining and configuring a PageSpeed Insights API key to resolve Lighthouse quota errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamsilverstein/wp-performance-wizard/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->