### PR TITLE
Correct link to connectors screen in admin

### DIFF
--- a/includes/class-performance-wizard-admin-page.php
+++ b/includes/class-performance-wizard-admin-page.php
@@ -53,7 +53,7 @@ class Performance_Wizard_Admin_Page {
 	 * @return string Admin URL to the Connectors screen.
 	 */
 	private function get_connectors_screen_url(): string {
-		$default = admin_url( 'admin.php?page=options-connectors' );
+		$default = admin_url( 'options-general.php?page=options-connectors-wp-admin' );
 		/**
 		 * Filters the URL of the core Connectors admin screen.
 		 *

--- a/includes/class-performance-wizard-admin-page.php
+++ b/includes/class-performance-wizard-admin-page.php
@@ -50,9 +50,12 @@ class Performance_Wizard_Admin_Page {
 	 * The precise slug is filterable so sites can point users at whatever
 	 * screen their WordPress install exposes the Connectors API on.
 	 *
+	 * Exposed as a static method so other classes (such as the REST API
+	 * handler) can reuse the same default and filter without duplicating it.
+	 *
 	 * @return string Admin URL to the Connectors screen.
 	 */
-	private function get_connectors_screen_url(): string {
+	public static function get_connectors_screen_url(): string {
 		$default = admin_url( 'options-general.php?page=options-connectors-wp-admin' );
 		/**
 		 * Filters the URL of the core Connectors admin screen.
@@ -142,7 +145,7 @@ class Performance_Wizard_Admin_Page {
 		if ( 0 === $model_count ) {
 			echo '<div class="notice notice-warning"><p>';
 			echo esc_html__( 'No AI models are configured. Connect an AI provider from the core Connectors screen to use the Performance Wizard.', 'wp-performance-wizard' );
-			echo ' <a href="' . esc_url( $this->get_connectors_screen_url() ) . '">' . esc_html__( 'Open Connectors', 'wp-performance-wizard' ) . '</a>';
+			echo ' <a href="' . esc_url( self::get_connectors_screen_url() ) . '">' . esc_html__( 'Open Connectors', 'wp-performance-wizard' ) . '</a>';
 			echo '</p></div>';
 			return;
 		}

--- a/includes/class-performance-wizard-rest-api.php
+++ b/includes/class-performance-wizard-rest-api.php
@@ -111,7 +111,7 @@ class Performance_Wizard_Rest_API {
 		$ai_required = array( '_get_next_action_', '_start_', '_run_action_', '_prompt_' );
 		if ( in_array( $command, $ai_required, true ) && null === $this->wizard->get_ai_agent() ) {
 			/** This filter is documented in includes/class-performance-wizard-admin-page.php */
-			$connectors_url = apply_filters( 'wp_performance_wizard_connectors_screen_url', admin_url( 'admin.php?page=options-connectors' ) );
+			$connectors_url = apply_filters( 'wp_performance_wizard_connectors_screen_url', admin_url( 'options-general.php?page=options-connectors-wp-admin' ) );
 			return new WP_REST_Response(
 				array(
 					'error'          => __( 'No AI provider is connected. Configure an AI connector (Anthropic, Google Gemini, or OpenAI) to run an analysis.', 'wp-performance-wizard' ),

--- a/includes/class-performance-wizard-rest-api.php
+++ b/includes/class-performance-wizard-rest-api.php
@@ -110,8 +110,7 @@ class Performance_Wizard_Rest_API {
 		// message instead of crashing downstream when no provider is connected.
 		$ai_required = array( '_get_next_action_', '_start_', '_run_action_', '_prompt_' );
 		if ( in_array( $command, $ai_required, true ) && null === $this->wizard->get_ai_agent() ) {
-			/** This filter is documented in includes/class-performance-wizard-admin-page.php */
-			$connectors_url = apply_filters( 'wp_performance_wizard_connectors_screen_url', admin_url( 'options-general.php?page=options-connectors-wp-admin' ) );
+			$connectors_url = Performance_Wizard_Admin_Page::get_connectors_screen_url();
 			return new WP_REST_Response(
 				array(
 					'error'          => __( 'No AI provider is connected. Configure an AI connector (Anthropic, Google Gemini, or OpenAI) to run an analysis.', 'wp-performance-wizard' ),


### PR DESCRIPTION
## Summary

Fixes the incorrect/outdated link to the core Connectors admin screen.

WordPress core registers the Connectors screen as a submenu of **Settings** (`options-general.php`) using the slug `options-connectors-wp-admin`. The plugin was pointing users at the wrong location: `admin.php?page=options-connectors`.

This updates both instances to the correct URL:

`options-general.php?page=options-connectors-wp-admin`

### Changes
- `includes/class-performance-wizard-admin-page.php` — the "Open Connectors" link shown on the settings UI when no AI is connected.
- `includes/class-performance-wizard-rest-api.php` — the `connectors_url` returned in the REST "No AI provider is connected" (503) error response.

The URL remains filterable via `wp_performance_wizard_connectors_screen_url`, so sites can still override it.

### Verification
- PHPCS: passes
- PHPStan: no errors

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation to the AI connectors settings page to use the correct admin URL path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->