### PR TITLE
Fix stored XSS in analysis terminal and history view

### DIFF
--- a/includes/js/wp-performance-wizard.js
+++ b/includes/js/wp-performance-wizard.js
@@ -273,7 +273,10 @@
 					terminal.appendChild( responseDiv );
 					await streamText( responseDiv, responseContent, 25 );
 				} else {
-					echoToTerminal( '<div class="dc"><br>' + responseContent + '</div>' );
+					const responseDiv = document.createElement( 'div' );
+					responseDiv.className = 'dc';
+					responseDiv.innerHTML = renderTerminalMarkdown( responseContent );
+					terminal.appendChild( responseDiv );
 				}
 			}
 		}
@@ -388,7 +391,10 @@
 						terminal.appendChild( responseDiv );
 						await streamText( responseDiv, result, 20 );
 					} else {
-						echoToTerminal( '<div class="dc">' + ( result || '' ) + '</div>' );
+						const responseDiv = document.createElement( 'div' );
+						responseDiv.className = 'dc';
+						responseDiv.innerHTML = renderTerminalMarkdown( result || '' );
+						terminal.appendChild( responseDiv );
 					}
 
 					// If the response includes a structured recommendations
@@ -474,10 +480,10 @@
 			const typeChar = () => {
 				if ( index < source.length ) {
 					index = Math.min( index + chunkSize, source.length );
-					element.innerHTML = marked.marked( source.substring( 0, index ) );
+					element.innerHTML = renderTerminalMarkdown( source.substring( 0, index ) );
 					setTimeout( typeChar, tickIntervalMs );
 				} else {
-					element.innerHTML = marked.marked( source );
+					element.innerHTML = renderTerminalMarkdown( source );
 					resolve();
 				}
 			};
@@ -715,7 +721,7 @@
 		terminal.innerHTML = '';
 
 		const header = document.createElement( 'div' );
-		header.innerHTML = marked.marked(
+		header.innerHTML = renderTerminalMarkdown(
 			'## Viewing past analysis (' + ( session.created || '' ) + ')\n\n' +
 			'_Model: ' + ( session.model || 'Unknown' ) + ' — read-only_'
 		);
@@ -730,12 +736,12 @@
 		transcript.forEach( function( entry ) {
 			if ( entry.title ) {
 				const heading = document.createElement( 'div' );
-				heading.innerHTML = marked.marked( '### ' + String( entry.title ) );
+				heading.innerHTML = renderTerminalMarkdown( '### ' + String( entry.title ) );
 				terminal.appendChild( heading );
 			}
 			const body = document.createElement( 'div' );
 			body.className = 'dc';
-			body.innerHTML = marked.marked( String( entry.content || '' ) );
+			body.innerHTML = renderTerminalMarkdown( String( entry.content || '' ) );
 			terminal.appendChild( body );
 
 			// If this entry is the final recommendations block and embeds a
@@ -1006,6 +1012,47 @@
 			return false;
 		}
 		return ! /^(javascript|data|vbscript|file):/i.test( trimmed );
+	}
+
+	/**
+	 * Render Markdown for display in the live terminal and history view.
+	 *
+	 * AI responses (and the analyzed site content that informs them) are
+	 * untrusted: a prompt-injection payload, a malicious plugin description, or
+	 * the model itself could emit raw HTML/script. The marked() default passes
+	 * raw HTML straight through, so rendering model output with it would execute
+	 * that markup in the admin's authenticated session. This routes everything
+	 * through renderSafeMarkdown() (raw HTML dropped, unsafe link/image
+	 * protocols neutralised), then re-adds only the one HTML feature the wizard
+	 * relies on - the follow-up question buttons - as a narrow, sanitized
+	 * allow-list with their labels escaped as plain text.
+	 *
+	 * @param {string} markdown Raw Markdown (potentially containing model HTML).
+	 * @returns {string} Safe HTML.
+	 */
+	function renderTerminalMarkdown( markdown ) {
+		const source = String( markdown || '' );
+
+		// Extract follow-up question button labels before raw HTML is stripped.
+		const followUps = [];
+		const buttonRe = /<button\b[^>]*\bwp-wizard-follow-up-question\b[^>]*>([\s\S]*?)<\/button>/gi;
+		let match;
+		while ( null !== ( match = buttonRe.exec( source ) ) ) {
+			const label = String( match[1] || '' ).replace( /<[^>]*>/g, '' ).trim();
+			if ( label ) {
+				followUps.push( label );
+			}
+		}
+
+		let html = renderSafeMarkdown( source );
+
+		// Re-add the follow-up questions as safe, allow-listed buttons with the
+		// label escaped so it can only ever render as text.
+		followUps.forEach( function( label ) {
+			html += '<button class="wp-wizard-follow-up-question">' + escapeHtmlAttr( label ) + '</button>';
+		} );
+
+		return html;
 	}
 
 	/**

--- a/includes/js/wp-performance-wizard.js
+++ b/includes/js/wp-performance-wizard.js
@@ -723,7 +723,8 @@
 		const header = document.createElement( 'div' );
 		header.innerHTML = renderTerminalMarkdown(
 			'## Viewing past analysis (' + ( session.created || '' ) + ')\n\n' +
-			'_Model: ' + ( session.model || 'Unknown' ) + ' — read-only_'
+			'_Model: ' + ( session.model || 'Unknown' ) + ' — read-only_',
+			{ allowFollowUps: false }
 		);
 		terminal.appendChild( header );
 
@@ -736,12 +737,12 @@
 		transcript.forEach( function( entry ) {
 			if ( entry.title ) {
 				const heading = document.createElement( 'div' );
-				heading.innerHTML = renderTerminalMarkdown( '### ' + String( entry.title ) );
+				heading.innerHTML = renderTerminalMarkdown( '### ' + String( entry.title ), { allowFollowUps: false } );
 				terminal.appendChild( heading );
 			}
 			const body = document.createElement( 'div' );
 			body.className = 'dc';
-			body.innerHTML = renderTerminalMarkdown( String( entry.content || '' ) );
+			body.innerHTML = renderTerminalMarkdown( String( entry.content || '' ), { allowFollowUps: false } );
 			terminal.appendChild( body );
 
 			// If this entry is the final recommendations block and embeds a
@@ -1027,30 +1028,34 @@
 	 * relies on - the follow-up question buttons - as a narrow, sanitized
 	 * allow-list with their labels escaped as plain text.
 	 *
-	 * @param {string} markdown Raw Markdown (potentially containing model HTML).
+	 * @param {string} markdown   Raw Markdown (potentially containing model HTML).
+	 * @param {Object} [options]  Render options. Pass { allowFollowUps: false }
+	 *                            from the read-only history view so archived
+	 *                            content does not re-inject live follow-up
+	 *                            buttons (there is no question input to drive
+	 *                            them there, and the live click handler would
+	 *                            throw once the terminal has been cleared).
 	 * @returns {string} Safe HTML.
 	 */
-	function renderTerminalMarkdown( markdown ) {
+	function renderTerminalMarkdown( markdown, options ) {
 		const source = String( markdown || '' );
-
-		// Extract follow-up question button labels before raw HTML is stripped.
-		const followUps = [];
-		const buttonRe = /<button\b[^>]*\bwp-wizard-follow-up-question\b[^>]*>([\s\S]*?)<\/button>/gi;
-		let match;
-		while ( null !== ( match = buttonRe.exec( source ) ) ) {
-			const label = String( match[1] || '' ).replace( /<[^>]*>/g, '' ).trim();
-			if ( label ) {
-				followUps.push( label );
-			}
-		}
+		const allowFollowUps = ! ( options && false === options.allowFollowUps );
 
 		let html = renderSafeMarkdown( source );
 
-		// Re-add the follow-up questions as safe, allow-listed buttons with the
-		// label escaped so it can only ever render as text.
-		followUps.forEach( function( label ) {
-			html += '<button class="wp-wizard-follow-up-question">' + escapeHtmlAttr( label ) + '</button>';
-		} );
+		if ( allowFollowUps ) {
+			// Extract follow-up question button labels (raw HTML was stripped by
+			// renderSafeMarkdown) and re-add them as safe, allow-listed buttons
+			// with the label escaped so it can only ever render as text.
+			const buttonRe = /<button\b[^>]*\bwp-wizard-follow-up-question\b[^>]*>([\s\S]*?)<\/button>/gi;
+			let match;
+			while ( null !== ( match = buttonRe.exec( source ) ) ) {
+				const label = String( match[1] || '' ).replace( /<[^>]*>/g, '' ).trim();
+				if ( label ) {
+					html += '<button class="wp-wizard-follow-up-question">' + escapeHtmlAttr( label ) + '</button>';
+				}
+			}
+		}
 
 		return html;
 	}


### PR DESCRIPTION
## Summary

Fixes a stored/reflected XSS vulnerability in the admin analysis UI.

The live analysis terminal and the saved-session viewer rendered AI responses with `marked.marked()`, which (in marked v14) passes raw HTML through unchanged - no sanitization. Since the analyzed content that informs those responses is untrusted (the site's front-end HTML, plugin descriptions, and wordpress.org metadata, any of which can be authored by a lower-privilege user or a third-party plugin), a prompt-injection payload - or the model itself - can emit `<script>`/`<img onerror>` that executes in the admin's authenticated session. The history path persisted the unsanitized content server-side and re-rendered it raw on every "View", making it a **stored** XSS.

The export path was already hardened via `renderSafeMarkdown()`; the live and history render paths were not. This PR closes that gap.

## What changed

- New `renderTerminalMarkdown()` helper: builds on the existing `renderSafeMarkdown()` (drops raw HTML pass-through, neutralises `javascript:`/`data:`/`vbscript:`/`file:` link and image protocols), then re-adds **only** the follow-up question buttons the wizard depends on, as a narrow allow-list with their labels escaped as plain text.
- Routed every untrusted-output path through it:
  - `streamText()` (streamed AI responses)
  - the short non-streamed answer branch in `outputFormattedResults()`
  - the short non-streamed recommendations branch
  - `renderStoredTranscript()` (header, per-entry heading, and body)
- `echoToTerminal()` is unchanged: it only ever renders the app's own trusted chrome (chips, status lines, server-built display prompts). No untrusted content reaches it anymore.

## Notes

- No behavior change for legitimate output: Markdown formatting still renders, and the follow-up question buttons still work.
- JS-only change; `node --check` passes. No JS linter is configured in the repo.

## Test plan

- [ ] Run an analysis and confirm responses, recommendations checklist, and follow-up buttons render and function as before.
- [ ] View a saved session from the history panel and confirm it renders read-only.
- [ ] Confirm a response containing `<img src=x onerror=alert(1)>` (or similar) renders inert instead of executing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined rendering of AI-generated responses for consistency across live and historical views.
  * Standardized output handling to ensure uniform display in terminal and transcript displays.
  * Follow-up question buttons remain functional in all rendering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->